### PR TITLE
Update Julia version used in CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ os:
 
 julia:
   - 1.0
-  - 1.2
+  - 1
   - nightly
 
 notifications:


### PR DESCRIPTION
Julia 1.0 and nightly are still kept, but
1.2 was updated to 1.6 (current stable).