### PR TITLE
Add compatibility info to project.toml

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,9 @@ Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
-julia = "^1.0"
+julia = "1"
+Distributions = "0.16, 0.17, 0.18, 0.19, 0.20, 0.24, 0.25"
+ForwardDiff = "0.9, 0.10"
 
 [extras]
 NBInclude = "0db19996-df87-5ea3-a455-e3a50d440464"


### PR DESCRIPTION
Some Distributions versions (v0.21, v0.22, v0.23) were left out because the tests failed with them (on windows Julia 1.6)
All other listed versions worked (but not every permutation was tested).
Hyphens were not used in version specifications because those officially require Julia 1.4 or newer.

This version specification is stricter than the autogenerated one in the Julia package registry, but
this is reasonable:
The oldest (now declared compatible) dependency releases are from 2018 (older than this package itself).
