### PR TITLE
fix(ekf): use Σ_Y instead of undefined ΣY in measure_info

### DIFF
--- a/src/ekf.jl
+++ b/src/ekf.jl
@@ -56,6 +56,6 @@ function measure_info(filter::ExtendedKalmanFilter, bp::GaussianBelief, y::Abstr
     μn = bp.μ + K * (y - yp)
     Σn = (I - K * H) * bp.Σ
         
-    info = (innovation_cov = ΣY, kalman_gain = K, predicted_measurement = yp)
+    info = (innovation_cov = Σ_Y, kalman_gain = K, predicted_measurement = yp)
     return GaussianBelief(μn, Σn), info
 end


### PR DESCRIPTION
Closes #50

The EKF `measure_info` function referenced `ΣY` in the returned info NamedTuple, but the local variable was named `Σ_Y`. This caused `UndefVarError` when `measure_info` was called (directly or via `update_with_info`), introduced in #43.

The KF (`src/kf.jl:68`) uses `ΣY` consistently and works. The UKF (`src/ukf.jl:164`) uses `Σ_Y` consistently and works. Only the EKF variant had the mismatch.

Verified locally — all package tests now pass.