### PR TITLE
build: update [compat] bounds to allow modern ForwardDiff and Distributions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,10 +11,10 @@ Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
-Distributions = "0.16, 0.17, 0.18, 0.19, 0.20, 0.24, 0.25"
-ForwardDiff = "0.9, 0.10"
-StableRNGs = "1.0.2"
-julia = "1"
+Distributions = "0.25"
+ForwardDiff = "0.10, 1"
+StableRNGs = "1"
+julia = "1.6"
 
 [extras]
 NBInclude = "0db19996-df87-5ea3-a455-e3a50d440464"


### PR DESCRIPTION
Closes #32

Updates Project.toml compat bounds to fix the issue that current ForwardDiff (1.x) is incompatible with the package as registered.

- ForwardDiff: `0.10, 1` (was `0.9, 0.10`) — adds support for ForwardDiff 1.x, which has been the released series for some time.
- Distributions: `0.25` (was `0.16, 0.17, ..., 0.25`) — drop the long legacy enumeration; 0.25 is the only series in modern use.
- StableRNGs: `1` (was `1.0.2`) — widen to the major series.
- julia: `1.6` (was `1`) — set a sensible LTS floor.

Verified locally — all tests pass on Julia 1.11 with the new bounds resolved.