### PR TITLE
fix(simulate): thread rng through simulation and use rng in rand(::GaussianBelief)

### DIFF
--- a/src/kf_classes.jl
+++ b/src/kf_classes.jl
@@ -91,5 +91,5 @@ function GaussianBelief(μ::AbstractVector,Σ::AbstractMatrix)
 end
 
 function Base.rand(rng::AbstractRNG, b::GaussianBelief)
-    return b.μ + cholesky(b.Σ).L * randn(size(b.Σ,1))
+    return b.μ + cholesky(b.Σ).L * randn(rng, size(b.Σ,1))
 end

--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -37,7 +37,7 @@ function simulation(filter::AbstractFilter, b0::GaussianBelief,
     state_history = [s0]
     measurement_history = Vector{AbstractVector{typeof(s0[1])}}()
     for u in action_sequence
-        xn, yn = simulate_step(filter, state_history[end], u)
+        xn, yn = simulate_step(filter, state_history[end], u, rng)
         push!(state_history, xn)
         push!(measurement_history, yn)
     end

--- a/test/test_ekf.jl
+++ b/test/test_ekf.jl
@@ -61,13 +61,13 @@ array_isapprox(first_update.Σ, first_predict_measure.Σ)
 @test size(μ) == (length(filtered_beliefs), length(filtered_beliefs[1].μ))
 @test size(Σ) == (length(filtered_beliefs), size(filtered_beliefs[1].Σ)...)
 
-array_isapprox(sim_states[end], [10.392777087830043, 1.881278839651635, 1.3840241662693935]; atol=0.001)
-array_isapprox(sim_measurements[end], [10.247812301812102, 2.3133675336888575, 1.1394960504116656]; atol=0.001)
-array_isapprox(filtered_beliefs[end].μ, [10.11546527880089, 1.9759609213772842, 1.2802257669046886];
+array_isapprox(sim_states[end], [9.476812080278332, -0.31100645773037805, 0.6082138148099138]; atol=0.001)
+array_isapprox(sim_measurements[end], [9.896156133972513, 0.23998395281014084, 0.7400708222590943]; atol=0.001)
+array_isapprox(filtered_beliefs[end].μ, [9.437578760960118, -0.2566452039031286, 0.4989401367606114];
                 atol=0.001)
-array_isapprox(filtered_beliefs[end].Σ, [0.22360753709112413 0.003704458778907191 -0.0053481184628957346;
-                                        0.003704458778907191 0.01690085173611888 -9.213406017856073e-5;
-                                        -0.0053481184628957346 -9.213406017856073e-5 0.016969928487616054]; atol=0.001)
+array_isapprox(filtered_beliefs[end].Σ, [0.01682790984107462 5.309144795905572e-5 2.5384310326873065e-5;
+                                        5.309144795905572e-5 0.01683608550354201 1.1576863526696874e-7;
+                                        2.5384310326873065e-5 1.1576863526696874e-7 0.01683587863740326]; atol=0.001)
 
 @test issymmetric(filtered_beliefs[end].Σ)  
 @test isposdef(filtered_beliefs[end].Σ) 

--- a/test/test_kf.jl
+++ b/test/test_kf.jl
@@ -47,11 +47,11 @@ array_isapprox(first_update.Σ, first_predict_measure.Σ)
 @test size(μ) == (length(filtered_beliefs), length(filtered_beliefs[1].μ))
 @test size(Σ) == (length(filtered_beliefs), size(filtered_beliefs[1].Σ)...)
 
-array_isapprox(sim_states[end], [98.92569494648434, -3.644139152469229, 247.30163635010385, 44.08105949503985]; atol=0.001)
-array_isapprox(sim_measurements[end], [-3.9598235926013814, 43.571078921455715]; atol=0.001)
-array_isapprox(filtered_beliefs[end].μ, [95.45866414957369, -4.222755472734632, 240.6036938459223, 44.10233946193025];
+array_isapprox(sim_states[end], [15.127850228241709, -12.45180498177378, 217.27241801616665, 36.520996773420705]; atol=0.001)
+array_isapprox(sim_measurements[end], [-12.281578317129972, 35.52338964170245]; atol=0.001)
+array_isapprox(filtered_beliefs[end].μ, [21.939873356215937, -12.934717045569819, 214.75050993679275, 36.220345386928344];
                 atol=0.001)
-array_isapprox(filtered_beliefs[end].Σ,   
+array_isapprox(filtered_beliefs[end].Σ,
 [12.60691909451178 0.03208712152522081 0.0 0.0; 0.03208712152522081 0.17912878474779198 0.0 0.0; 0.0 0.0 12.60691909451178 0.03208712152522081; 0.0 0.0 0.03208712152522081 0.17912878474779198]; atol=0.001)
 
 @test issymmetric(filtered_beliefs[end].Σ)  

--- a/test/test_models.jl
+++ b/test/test_models.jl
@@ -55,3 +55,12 @@ end
     o2 = measure(om, x0, u0, rng)
     @test all(x -> !isapprox(x, 1.0), o2)
 end
+
+@testset "GaussianBelief sampling honors RNG" begin
+    b = GaussianBelief(zeros(3), Matrix{Float64}(I, 3, 3))
+    s1 = rand(MersenneTwister(42), b)
+    s2 = rand(MersenneTwister(42), b)
+    @test s1 == s2
+    s3 = rand(MersenneTwister(43), b)
+    @test s1 != s3
+end

--- a/test/test_ukf.jl
+++ b/test/test_ukf.jl
@@ -57,13 +57,13 @@ array_isapprox(first_update.Σ, first_predict_measure.Σ)
 @test size(μ) == (length(filtered_beliefs), length(filtered_beliefs[1].μ))
 @test size(Σ) == (length(filtered_beliefs), size(filtered_beliefs[1].Σ)...)
 
-array_isapprox(sim_states[end], [1.714900932988236, 3.3565392853948817, 1.6667294444469274]; atol=0.001)
-array_isapprox(sim_measurements[end], [3.69153933548104]; atol=0.001)
-array_isapprox(filtered_beliefs[end].μ, [1.4814619638776565, 3.4326616712795706, 1.6161163605801583];
+array_isapprox(sim_states[end], [2.1938145867651793, 1.6545630730412542, 0.8035411104321245]; atol=0.001)
+array_isapprox(sim_measurements[end], [3.089334840070635]; atol=0.001)
+array_isapprox(filtered_beliefs[end].μ, [1.1028300859903188, 2.2374376691887146, 1.5249560207395012];
                 atol=0.001)
-array_isapprox(filtered_beliefs[end].Σ, [0.8598017439163512 -0.3671915250027322 -0.28904437017769147;
-                                        -0.3671915250027322 0.18824642668739394 0.1331601839776194;
-                                        -0.28904437017769147 0.1331601839776194 0.17348866695878715]; atol=0.001)
+array_isapprox(filtered_beliefs[end].Σ, [0.9739652009561084 -0.45775426426788585 -0.3806500873367031;
+                                        -0.45775426426788585 0.25772590492257236 0.19537410795801752;
+                                        -0.3806500873367031 0.19537410795801752 0.2254038829167196]; atol=0.001)
 
 @test issymmetric(filtered_beliefs[end].Σ)  
 @test isposdef(filtered_beliefs[end].Σ) 


### PR DESCRIPTION
Closes #41, closes #40

Two coupled fixes ensure simulation reproducibility actually respects the rng argument:

- `src/kf_classes.jl`: `rand(rng, ::GaussianBelief)` now passes `rng` to `randn()` instead of falling through to the global RNG.
- `src/simulate.jl`: `simulation()` now passes `rng` to `simulate_step()` inside the action loop instead of relying on the global RNG.

The previously hard-coded EKF/KF/UKF test values were generated when the global RNG (seeded by `Random.seed!(0)` in runtests.jl) was being used everywhere; now that `StableRNG(0)` actually propagates through simulation, the expected sim outputs and posterior means change. Posterior covariances for the linear KF are unaffected (Σ is data-independent for linear filters).

Adds a small regression test that `rand(rng, b)` is reproducible across identical RNG seeds and varies with different seeds.

Verified locally — all tests pass.