### PR TITLE
feat(belief): accept UniformScaling for GaussianBelief covariance + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,18 +44,30 @@ b0 = GaussianBelief([0, 0], [1 0; 0 1])
 b1 = update(ukf, b0, action, measurement)
 ```
 
-See documentation and examples for more details.
+Covariances may be passed as any `AbstractMatrix`, or in identity form
+(`I(n)`, `s*I(n)`). `GaussianBelief` also accepts a bare `UniformScaling`,
+inferring the size from the mean vector:
+
+```julia
+b0 = GaussianBelief([0.0, 0.0], 2.0*I)   # Σ becomes 2*I(2)
+```
+
+See the `examples/` directory for full demonstrations.
 
 ## Examples
 
-Examples notebooks can be found in the `notebooks` folder:
+Each example script lives in `examples/` with its own `Project.toml`.
+Run any of them with:
 
-[Kalman Filter Example](https://github.com/sisl/GaussianFilters.jl/blob/master/notebooks/KF_2DMotionExample.ipynb)
+```sh
+julia --project=examples examples/kf_2d_motion.jl
+```
 
-[Extended Kalman Filter Example](https://github.com/sisl/GaussianFilters.jl/blob/master/notebooks/EKF_SpinningSatelliteExample.ipynb)
-
-[Unscented Kalman Filter Example](https://github.com/sisl/GaussianFilters.jl/blob/master/notebooks/UKF_NonholonomicRobot.ipynb)
-
-[GM-PHD Object Surveillance Example](https://github.com/sisl/GaussianFilters.jl/blob/master/notebooks/GMPHD_SurveillanceExample.ipynb)
-
-[GM-PHD Aircraft Carrier Example](https://github.com/sisl/GaussianFilters.jl/blob/master/notebooks/GMPHD_AircraftCarrierExample.ipynb)
+| Script | Filter | Description |
+|---|---|---|
+| [`kf_2d_motion.jl`](examples/kf_2d_motion.jl) | KF | 2D point-mass with linear dynamics |
+| [`ekf_spinning_satellite.jl`](examples/ekf_spinning_satellite.jl) | EKF | Rigid-body rotation with saturated observations |
+| [`ukf_nonholonomic_robot.jl`](examples/ukf_nonholonomic_robot.jl) | UKF | Differential-drive robot with range observation |
+| [`gmphd_surveillance.jl`](examples/gmphd_surveillance.jl) | GM-PHD | Multi-target tracking |
+| [`gmphd_aircraft_carrier.jl`](examples/gmphd_aircraft_carrier.jl) | GM-PHD | Aircraft carrier scenario |
+| [`gmphd_tests.jl`](examples/gmphd_tests.jl) | GM-PHD | Visualization helpers |

--- a/src/kf_classes.jl
+++ b/src/kf_classes.jl
@@ -90,6 +90,10 @@ function GaussianBelief(μ::AbstractVector,Σ::AbstractMatrix)
     return GaussianBelief(μ,Symmetric(Σ))
 end
 
+function GaussianBelief(μ::AbstractVector, Σ::UniformScaling)
+    return GaussianBelief(μ, Σ(length(μ)))
+end
+
 function Base.rand(rng::AbstractRNG, b::GaussianBelief)
     return b.μ + cholesky(b.Σ).L * randn(rng, size(b.Σ,1))
 end

--- a/test/test_models.jl
+++ b/test/test_models.jl
@@ -64,3 +64,16 @@ end
     s3 = rand(MersenneTwister(43), b)
     @test s1 != s3
 end
+
+@testset "Identity-form covariances" begin
+    # I(n) constructs a sized Diagonal — accepted everywhere a matrix is
+    @test GaussianBelief(zeros(3), I(3)) isa GaussianBelief
+    @test LinearDynamicsModel(zeros(3,3), zeros(3,3), 0.5*I(3)) isa LinearDynamicsModel
+    @test NonlinearDynamicsModel((x,u)->x, 0.5*I(3)) isa NonlinearDynamicsModel
+
+    # Bare UniformScaling is accepted by GaussianBelief — size inferred from μ
+    b = GaussianBelief([1.0, 2.0, 3.0], 2.0*I)
+    @test b isa GaussianBelief
+    @test size(b.Σ) == (3,3)
+    @test b.Σ[1,1] ≈ 2.0
+end


### PR DESCRIPTION
Closes #11

**This PR is stacked on top of #54.** Review #54 first, or wait for it to merge before reviewing this.

- Add `GaussianBelief(μ, ::UniformScaling)` constructor that infers dimension from the mean vector, so `s*I` works as a covariance argument (in addition to the already-working `s*I(n)` form).
- Add regression tests covering `I(n)`, `s*I(n)`, and bare `UniformScaling` across `LinearDynamicsModel`, `NonlinearDynamicsModel`, `GaussianBelief`.
- Update README example to demonstrate I-form covariances and point to `examples/` instead of the removed `notebooks/` directory.