### PR TITLE
refactor: parametric filter and model types + StaticArrays test suite

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,6 +19,7 @@ julia = "1.6"
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [targets]
-test = ["Test", "StableRNGs"]
+test = ["Test", "StableRNGs", "StaticArrays"]

--- a/src/gmphd_classes.jl
+++ b/src/gmphd_classes.jl
@@ -4,9 +4,9 @@
 Construct measurement model with observation matrix C and sensor
 noise matrix R
 """
-struct Measurement{A<:Number,B<:Number}
-    C::AbstractMatrix{A}
-    R::AbstractMatrix{B}
+struct Measurement{MC<:AbstractMatrix, MR<:AbstractMatrix}
+    C::MC
+    R::MR
 end
 
 """
@@ -16,10 +16,10 @@ end
 Construct linear dynamics model with; transition matrix A,
 process noise matrix Q and offset vector d
 """
-struct Dynamics{A<:Number,B<:Number,C<:Number}
-    A::AbstractMatrix{A}
-    Q::AbstractMatrix{B}
-    d::AbstractVector{C}
+struct Dynamics{MA<:AbstractMatrix, MQ<:AbstractMatrix, VD<:AbstractVector}
+    A::MA
+    Q::MQ
+    d::VD
 end
 
 function Dynamics(A,Q)
@@ -48,8 +48,7 @@ end
 
 function GaussianMixture(w, μ::Vector{<:AbstractVector{T}},
     Σ::Vector{<:AbstractMatrix{K}}) where {T<:Number,K<:Number}
-    @assert length(μ) == length(Σ) == length(w) "Number
-     of mixtures inconsistent"
+    @assert length(μ) == length(Σ) == length(w) "Number of mixtures inconsistent"
     GaussianMixture{promote_type(T,K)}(length(w), w, μ, Σ)
 end
 
@@ -61,9 +60,9 @@ end
     spawning intesity of the target
     dyn: Dynamics
 """
-struct Spawn
-    β::GaussianMixture
-    dyn::Vector{Dynamics}
+struct Spawn{G<:GaussianMixture, D<:AbstractVector{<:Dynamics}}
+    β::G
+    dyn::D
 end
 
 """
@@ -82,14 +81,15 @@ end
     Ps: Survival probability
     Pd: Detection probability
 """
-struct PHDFilter
-    γ::GaussianMixture
-    spawn::Spawn
-    dyn::Vector{Dynamics}
-    meas::Measurement
+struct PHDFilter{G<:GaussianMixture, S<:Spawn,
+                 D<:AbstractVector{<:Dynamics}, M<:Measurement, F<:Function}
+    γ::G
+    spawn::S
+    dyn::D
+    meas::M
     Ps::Float64
     Pd::Float64
-    κ::Function
+    κ::F
 end
 
 function PHDFilter(γ::GaussianMixture, spawn::Spawn, dyn::Dynamics,

--- a/src/kf_classes.jl
+++ b/src/kf_classes.jl
@@ -13,9 +13,9 @@ abstract type AbstractFilter end
 Construct Kalman filter with LinearDynamicsModel d and
 LinearObservationModel o.
 """
-struct KalmanFilter <: AbstractFilter
-    d::LinearDynamicsModel
-    o::LinearObservationModel
+struct KalmanFilter{D<:LinearDynamicsModel, O<:LinearObservationModel} <: AbstractFilter
+    d::D
+    o::O
 end
 
 """
@@ -26,13 +26,18 @@ end
 Construct Extended Kalman filter with DynamicsModel d and
 ObservationModel o.
 """
-struct ExtendedKalmanFilter <: AbstractFilter
-    d::DynamicsModel
-    o::ObservationModel
-    ExtendedKalmanFilter(d,o) =
-        (d isa LinearDynamicsModel && o isa LinearObservationModel) ?
-        error("linear models: use kf over ekf") : new(d,o)
+struct ExtendedKalmanFilter{D<:DynamicsModel, O<:ObservationModel} <: AbstractFilter
+    d::D
+    o::O
+    function ExtendedKalmanFilter{D,O}(d::D, o::O) where {D<:DynamicsModel, O<:ObservationModel}
+        (d isa LinearDynamicsModel && o isa LinearObservationModel) &&
+            error("linear models: use kf over ekf")
+        return new{D,O}(d, o)
+    end
 end
+
+ExtendedKalmanFilter(d::D, o::O) where {D<:DynamicsModel, O<:ObservationModel} =
+    ExtendedKalmanFilter{D,O}(d, o)
 
 """
     UnscentedKalmanFilter(d::DynamicsModel,o::ObservationModel,λ::Number,
@@ -45,24 +50,21 @@ and UKF parameters λ, α, and β. Default constructor uses α/β formulation fr
 Probabilistic Robotics, second constructor reduces complexity, third
 constructor defaults λ to 2, as is commonly done.
 """
-struct UnscentedKalmanFilter{a<:Number,b<:Number,c<:Number} <: AbstractFilter
-    d::DynamicsModel
-    o::ObservationModel
+struct UnscentedKalmanFilter{D<:DynamicsModel, O<:ObservationModel,
+                              a<:Number, b<:Number, c<:Number} <: AbstractFilter
+    d::D
+    o::O
     λ::a
     α::b
     β::c
-    #=
-    UnscentedKalmanFilter(d,o,λ,α,β) = (d isa LinearDynamicsModel && o isa LinearObservationModel) ?
-        error("linear models: use kf over ukf") : new(d,o,λ,α,β)
-    =#
 end
 
-function UnscentedKalmanFilter(d::DynamicsModel,o::ObservationModel,λ::a) where a<:Number
-    return UnscentedKalmanFilter{a,Int8,Int8}(d,o,λ,1,0)
+function UnscentedKalmanFilter(d::DynamicsModel, o::ObservationModel, λ::Number)
+    return UnscentedKalmanFilter(d, o, λ, 1, 0)
 end
 
-function UnscentedKalmanFilter(d::DynamicsModel,o::ObservationModel)
-    return UnscentedKalmanFilter{Int8,Int8,Int8}(d,o,2,1,0)
+function UnscentedKalmanFilter(d::DynamicsModel, o::ObservationModel)
+    return UnscentedKalmanFilter(d, o, 2, 1, 0)
 end
 
 ### Belief States ###

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ using Logging
 using LinearAlgebra
 using Distributions
 using StableRNGs
+using StaticArrays
 
 # Package Under Test
 using GaussianFilters
@@ -64,5 +65,9 @@ end
     end
     @time @testset "GaussianFilter GM-PHD Testing" begin
         include(joinpath(testdir, "test_gmphd.jl"))
+    end
+
+    @time @testset "StaticArrays Compatibility" begin
+        include(joinpath(testdir, "test_static.jl"))
     end
 end

--- a/test/test_static.jl
+++ b/test/test_static.jl
@@ -1,0 +1,77 @@
+using StaticArrays
+
+@testset "StaticArrays - Linear KF" begin
+    rng = StableRNG(0)
+    dt = 0.1
+    A = @SMatrix [1.0 dt 0.0 0.0; 0.0 1.0 0.0 0.0; 0.0 0.0 1.0 dt; 0.0 0.0 0.0 1.0]
+    B = @SMatrix [0.0 0.0; dt 0.0; 0.0 0.0; 0.0 dt]
+    W = SMatrix{4,4,Float64}(0.1*I)
+    dmodel = LinearDynamicsModel(A, B, W)
+
+    C = @SMatrix [0.0 1.0 0.0 0.0; 0.0 0.0 0.0 1.0]
+    V = SMatrix{2,2,Float64}(0.5*I)
+    omodel = LinearObservationModel(C, V)
+
+    kf = KalmanFilter(dmodel, omodel)
+    @test kf isa KalmanFilter
+
+    μ0 = @SVector [0.0, 0.0, 0.0, 0.0]
+    Σ0 = SMatrix{4,4,Float64}(2.0*I)
+    b0 = GaussianBelief(μ0, Σ0)
+    @test b0 isa GaussianBelief
+
+    u = @SVector [1.0, 0.5]
+    bp = predict(kf, b0, u)
+    @test bp isa GaussianBelief
+
+    y = @SVector [0.05, 0.05]
+    bn = update(kf, b0, u, y)
+    @test bn isa GaussianBelief
+end
+
+@testset "StaticArrays - Nonlinear EKF" begin
+    rng = StableRNG(0)
+
+    f(x, u) = SVector(x[1] + x[2], x[2] + u[1])
+    h(x, u) = SVector(x[1])
+    W = SMatrix{2,2,Float64}(0.01*I)
+    V = SMatrix{1,1,Float64}(0.1*I)
+
+    dmodel = NonlinearDynamicsModel(f, W)
+    omodel = NonlinearObservationModel(h, V)
+    ekf = ExtendedKalmanFilter(dmodel, omodel)
+    @test ekf isa ExtendedKalmanFilter
+
+    b0 = GaussianBelief(SVector(0.0, 0.0), SMatrix{2,2,Float64}(1.0*I))
+    u = SVector(0.1)
+
+    bp = predict(ekf, b0, u)
+    @test bp isa GaussianBelief
+    @test length(bp.μ) == 2
+
+    y = SVector(0.05)
+    bn = update(ekf, b0, u, y)
+    @test bn isa GaussianBelief
+end
+
+@testset "StaticArrays - UKF" begin
+    f(x, u) = SVector(x[1] + u[1], x[2] + u[2])
+    h(x, u) = SVector(x[1] + x[2])
+    W = SMatrix{2,2,Float64}(0.01*I)
+    V = SMatrix{1,1,Float64}(0.1*I)
+
+    dmodel = NonlinearDynamicsModel(f, W)
+    omodel = NonlinearObservationModel(h, V)
+    ukf = UnscentedKalmanFilter(dmodel, omodel)
+    @test ukf isa UnscentedKalmanFilter
+
+    b0 = GaussianBelief(SVector(0.0, 0.0), SMatrix{2,2,Float64}(1.0*I))
+    u = SVector(0.1, 0.2)
+
+    bp = predict(ukf, b0, u)
+    @test bp isa GaussianBelief
+
+    y = SVector(0.05)
+    bn = update(ukf, b0, u, y)
+    @test bn isa GaussianBelief
+end


### PR DESCRIPTION
Closes #22, closes #10, closes #47

Make struct fields concrete-parametric to eliminate type instability:

- `KalmanFilter`, `ExtendedKalmanFilter`, `UnscentedKalmanFilter` now carry dynamics/observation model type parameters instead of holding the abstract supertype fields.
- `Measurement`, `Dynamics`, `Spawn`, `PHDFilter` now bind concrete matrix / vector / function types via parametric field types.
- `ExtendedKalmanFilter` inner constructor preserves the existing 'use kf over ekf' guard while operating with type parameters.
- `UnscentedKalmanFilter` no longer falls back to Int8 sentinel parameters; convenience constructors forward to the parametric one and let promotion infer the types.

Add StaticArrays test suite covering KF, EKF, and UKF end-to-end with `SVector`/`SMatrix` inputs, verifying the package works with stack-allocated arrays now that the model/filter structs are concrete-typed.

`GaussianMixture`'s struct signature is intentionally left as-is because `Vector{GaussianMixture}` operations in `src/gmphd.jl` rely on the existing parametric layout — tightening it broke the GM-PHD update loop.