### PR TITLE
feat(pomdps): POMDPs.jl integration via package extension + pendulum demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 docs/build
 *.ipynb_checkpoints*
 *Manifest.toml
+examples/outputs/

--- a/Project.toml
+++ b/Project.toml
@@ -10,16 +10,24 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
+[weakdeps]
+POMDPs = "a93abf59-7444-517b-a68a-c42f96afdd7d"
+
+[extensions]
+GaussianFiltersPOMDPsExt = "POMDPs"
+
 [compat]
 Distributions = "0.25"
 ForwardDiff = "0.10, 1"
+POMDPs = "0.9, 1"
 StableRNGs = "1"
-julia = "1.6"
+julia = "1.9"
 
 [extras]
+POMDPs = "a93abf59-7444-517b-a68a-c42f96afdd7d"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [targets]
-test = ["Test", "StableRNGs", "StaticArrays"]
+test = ["POMDPs", "Test", "StableRNGs", "StaticArrays"]

--- a/examples/Project.toml
+++ b/examples/Project.toml
@@ -4,9 +4,11 @@ ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 GaussianFilters = "08d575fb-911d-541e-8431-6cfa767e7851"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 POMDPModels = "355abbd5-f08e-5560-ac9e-8b5f2592a0ca"
+POMDPTools = "7588e00f-9cae-40de-98dc-e0c70c48cdd7"
 POMDPs = "a93abf59-7444-517b-a68a-c42f96afdd7d"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [sources]
 GaussianFilters = {path = ".."}

--- a/examples/Project.toml
+++ b/examples/Project.toml
@@ -1,7 +1,9 @@
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 GaussianFilters = "08d575fb-911d-541e-8431-6cfa767e7851"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+POMDPModels = "355abbd5-f08e-5560-ac9e-8b5f2592a0ca"
 POMDPs = "a93abf59-7444-517b-a68a-c42f96afdd7d"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/examples/Project.toml
+++ b/examples/Project.toml
@@ -2,6 +2,7 @@
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 GaussianFilters = "08d575fb-911d-541e-8431-6cfa767e7851"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+POMDPs = "a93abf59-7444-517b-a68a-c42f96afdd7d"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,6 +11,7 @@ Self-contained example scripts demonstrating the filters in `GaussianFilters.jl`
 | `gmphd_aircraft_carrier.jl` | GM-PHD | Aircraft carrier scenario with birth/spawn models |
 | `gmphd_tests.jl` | GM-PHD | Visualization helpers and pruning/merging demos |
 | `pomdps_integration.jl` | KF | Uses a `KalmanFilter` as a `POMDPs.jl` belief updater |
+| `pendulum_ekf_ilqr.jl` | EKF | Closed-loop stabilization of `POMDPModels.InvertedPendulum` from partial observations, with an iLQR policy on the belief mean |
 
 ## Running
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,7 +11,7 @@ Self-contained example scripts demonstrating the filters in `GaussianFilters.jl`
 | `gmphd_aircraft_carrier.jl` | GM-PHD | Aircraft carrier scenario with birth/spawn models |
 | `gmphd_tests.jl` | GM-PHD | Visualization helpers and pruning/merging demos |
 | `pomdps_integration.jl` | KF | Uses a `KalmanFilter` as a `POMDPs.jl` belief updater |
-| `pendulum_ekf_ilqr.jl` | EKF | Closed-loop stabilization of `POMDPModels.InvertedPendulum` from partial observations, with an iLQR policy on the belief mean |
+| `pendulum_ekf_ilqr.jl` | EKF | Closed-loop stabilization of an inverted pendulum from partial (angle-only) observations. Defines a `PendulumPOMDP` and an `ILQRPolicy <: POMDPs.Policy`, wraps the EKF with `pomdps_updater`, and runs everything through `POMDPs.simulate`. Writes an animation to `examples/outputs/pendulum_ekf_ilqr.gif` (gitignored). |
 
 ## Running
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,6 +10,7 @@ Self-contained example scripts demonstrating the filters in `GaussianFilters.jl`
 | `gmphd_surveillance.jl` | GM-PHD | Multi-target tracking in a surveillance region |
 | `gmphd_aircraft_carrier.jl` | GM-PHD | Aircraft carrier scenario with birth/spawn models |
 | `gmphd_tests.jl` | GM-PHD | Visualization helpers and pruning/merging demos |
+| `pomdps_integration.jl` | KF | Uses a `KalmanFilter` as a `POMDPs.jl` belief updater |
 
 ## Running
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,7 +11,7 @@ Self-contained example scripts demonstrating the filters in `GaussianFilters.jl`
 | `gmphd_aircraft_carrier.jl` | GM-PHD | Aircraft carrier scenario with birth/spawn models |
 | `gmphd_tests.jl` | GM-PHD | Visualization helpers and pruning/merging demos |
 | `pomdps_integration.jl` | KF | Uses a `KalmanFilter` as a `POMDPs.jl` belief updater |
-| `pendulum_ekf_ilqr.jl` | EKF | Closed-loop stabilization of an inverted pendulum from partial (angle-only) observations. Defines a `PendulumPOMDP` and an `ILQRPolicy <: POMDPs.Policy`, wraps the EKF with `pomdps_updater`, and runs everything through `POMDPs.simulate`. Writes an animation to `examples/outputs/pendulum_ekf_ilqr.gif` (gitignored). |
+| `pendulum_ekf_ilqr.jl` | EKF | Closed-loop stabilization of an inverted pendulum observed only through its angular velocity (gyroscope-style). The angle is hidden and inferred by the EKF. Defines a `PendulumPOMDP` and an `ILQRPolicy <: POMDPs.Policy`, wraps the EKF with `pomdps_updater`, and runs everything through `POMDPs.simulate`. Writes an animation showing belief uncertainty (±2σ) on both states to `examples/outputs/pendulum_ekf_ilqr.gif` (gitignored). |
 
 ## Running
 

--- a/examples/pendulum_ekf_ilqr.jl
+++ b/examples/pendulum_ekf_ilqr.jl
@@ -94,7 +94,7 @@ Distributions.cov(d::SVecMvNormal)  = cov(d.mvn)
 POMDPs.initialize_belief(u::POMDPs.Updater, d::SVecMvNormal) = POMDPs.initialize_belief(u, d.mvn)
 
 POMDPs.initialstate(::PendulumPOMDP) =
-    SVecMvNormal(MvNormal([0.6, 0.0], Matrix(Diagonal([0.05, 0.1]))))
+    SVecMvNormal(MvNormal([0.0, 0.0], Matrix(Diagonal([0.5^2, 0.1^2]))))
 
 POMDPs.isterminal(p::PendulumPOMDP, s::AbstractVector) = abs(s[1]) > p.θ_max
 POMDPs.discount(p::PendulumPOMDP) = p.γ

--- a/examples/pendulum_ekf_ilqr.jl
+++ b/examples/pendulum_ekf_ilqr.jl
@@ -1,78 +1,136 @@
-# Stabilizing a noisy inverted pendulum from partial observations
-# ================================================================
+# Stabilizing a noisy inverted pendulum with EKF beliefs + iLQR control
+# =====================================================================
 #
-# Demonstrates the GaussianFilters <-> POMDPs.jl integration in a closed
-# control loop. At each step we
-#   1. observe a noisy angle (the angular velocity is hidden),
-#   2. update the EKF belief via POMDPs.update,
-#   3. plan a torque sequence with iLQR using belief.μ as the starting
-#      state (certainty equivalent control — iLQR ignores belief.Σ),
-#   4. apply the first planned action.
-#
-# The dynamics are pulled from POMDPModels.InvertedPendulum so we are
-# integrating against the real ecosystem rather than a private copy.
+# This example defines a partial-observation `PendulumPOMDP`, uses an
+# `ExtendedKalmanFilter` wrapped as a `POMDPs.Updater`, and an
+# `ILQRPolicy` that runs iterative LQR on the belief mean (certainty
+# equivalence — iLQR ignores belief covariance). The closed loop is
+# driven by `POMDPs.simulate`, not a hand-rolled control loop.
 
 using GaussianFilters
 using POMDPs
+using POMDPTools: HistoryRecorder, eachstep
 using POMDPModels: InvertedPendulum
 using LinearAlgebra
 using Random
 using ForwardDiff
+using StaticArrays
+import Distributions
 using Distributions: MvNormal
 
-# ----- dynamics & observation models -----
-#
-# We pull parameters from POMDPModels.InvertedPendulum and re-implement
-# the Euler step generically (the POMDPModels.euler signature pins state
-# to Tuple{Float64,Float64}, which blocks ForwardDiff dual numbers).
+# Plots is needed for the animation block at the end. Loading it up
+# front so that macros (@animate, gif) are available at parse time.
+ENV["GKSwstype"] = "100"
+using Plots
 
-const ip = InvertedPendulum()
-const σ_proc = 0.01    # process noise std per state component
-const σ_obs  = 0.05    # angle observation noise std (rad)
+# ---------------------------------------------------------------------
+# Dynamics
+# ---------------------------------------------------------------------
+# Parameters are pulled from POMDPModels.InvertedPendulum so we are not
+# inventing physical constants. We re-express the Euler step generically
+# because POMDPModels.euler is signature-locked to Tuple{Float64,Float64}
+# and blocks ForwardDiff dual numbers (which are used both inside the
+# EKF Jacobian and inside the iLQR linearization).
 
-function dwdt(th, w, u, m=ip)
+const IP = InvertedPendulum()
+
+function dwdt(th, w, u, m = IP)
     num = m.g*sin(th) - m.alpha*m.m*m.l*(w^2)*sin(2*th)*0.5 - m.alpha*cos(th)*u
     den = (4/3)*m.l - m.alpha*m.l*(cos(th)^2)
-    return num/den
+    return num / den
 end
 
+# Deterministic Euler step. Returns an SVector to exercise our
+# StaticArrays compatibility end-to-end.
 function pendulum_step(x::AbstractVector, u::AbstractVector)
     th, w, ut = x[1], x[2], u[1]
     alph = dwdt(th, w, ut)
-    return [th + w*ip.dt + 0.5*alph*ip.dt^2,
-            w + alph*ip.dt]
+    return SVector{2}(th + w*IP.dt + 0.5*alph*IP.dt^2,
+                      w + alph*IP.dt)
 end
 
-# Observation: noisy measurement of the angle only.
-observe_angle(x::AbstractVector, u::AbstractVector) = [x[1]]
+# Observe the angle only; angular velocity must be inferred by the EKF.
+observe_angle(x::AbstractVector, u::AbstractVector) = SVector{1}(x[1])
 
-W = σ_proc^2 * Matrix{Float64}(I, 2, 2)
-V = (σ_obs^2)  * Matrix{Float64}(I, 1, 1)
+# ---------------------------------------------------------------------
+# POMDP definition
+# ---------------------------------------------------------------------
 
-dmodel = NonlinearDynamicsModel(pendulum_step, W)
-omodel = NonlinearObservationModel(observe_angle, V)
-ekf = ExtendedKalmanFilter(dmodel, omodel)
+const σ_proc = 0.01    # process noise std (per state component)
+const σ_obs  = 0.05    # angle observation noise std (rad)
 
-# ----- minimal iLQR -----
-#
-# Standard LQR backward pass on the linearization of pendulum_step around
-# the current nominal trajectory, with a quadratic stage cost
-#
-#   ℓ(x,u) = xᵀ Q x + uᵀ R u
-#
-# and quadratic terminal cost xᵀ Qf x. We linearize via ForwardDiff at
-# every step of the forward roll, do one backward LQR sweep to compute
-# feedback gains, and return the resulting control sequence. No line
-# search, no regularization — sufficient to stabilize from a small
-# perturbation (θ₀ ~ 0.3) but not to swing up from θ = π.
+struct PendulumPOMDP <: POMDP{SVector{2,Float64}, SVector{1,Float64}, SVector{1,Float64}}
+    σ_proc::Float64
+    σ_obs::Float64
+    dt::Float64
+    θ_max::Float64       # episode terminates if |θ| exceeds this
+    γ::Float64
+end
 
-const Q  = Diagonal([10.0, 1.0])        # stage cost on (θ, ω)
-const Qf = Diagonal([100.0, 10.0])      # terminal cost
-const R  = Diagonal([0.01])             # control effort
+PendulumPOMDP() = PendulumPOMDP(σ_proc, σ_obs, IP.dt, π, 0.99)
 
-function rollout(x0::Vector{Float64}, us::Vector{Vector{Float64}})
+# Initial-state distribution: a Gaussian over (θ, ω). HistoryRecorder
+# samples the true initial state from this and `initialize_belief` reads
+# the same distribution's mean/cov (via our extension) to seed the EKF.
+# We wrap MvNormal so `rand` returns an SVector instead of a Vector.
+struct SVecMvNormal
+    mvn::MvNormal
+end
+Base.rand(rng::AbstractRNG, d::SVecMvNormal) = SVector{2}(rand(rng, d.mvn))
+Distributions.mean(d::SVecMvNormal) = mean(d.mvn)
+Distributions.cov(d::SVecMvNormal)  = cov(d.mvn)
+# Forward initialize_belief to the underlying MvNormal so our extension picks it up.
+POMDPs.initialize_belief(u::POMDPs.Updater, d::SVecMvNormal) = POMDPs.initialize_belief(u, d.mvn)
+
+POMDPs.initialstate(::PendulumPOMDP) =
+    SVecMvNormal(MvNormal([0.6, 0.0], Matrix(Diagonal([0.05, 0.1]))))
+
+POMDPs.isterminal(p::PendulumPOMDP, s::AbstractVector) = abs(s[1]) > p.θ_max
+POMDPs.discount(p::PendulumPOMDP) = p.γ
+
+# `gen` is the generative interface: (next_state, observation, reward).
+# Relaxing the state argument to AbstractVector (rather than SVector{2})
+# accommodates POMDPs' internal handling.
+function POMDPs.gen(p::PendulumPOMDP, s::AbstractVector, a::AbstractVector, rng)
+    sp = pendulum_step(s, a) .+ p.σ_proc .* SVector{2}(randn(rng), randn(rng))
+    o  = observe_angle(sp, a) .+ p.σ_obs .* SVector{1}(randn(rng))
+    r  = -(s[1]^2 + 0.1*s[2]^2 + 0.01*a[1]^2)
+    return (sp = sp, o = o, r = r)
+end
+
+# ---------------------------------------------------------------------
+# ILQRPolicy
+# ---------------------------------------------------------------------
+# Holds only iLQR hyperparameters + warm-start solver state. No belief,
+# no EKF — that's the Updater's job.
+
+mutable struct ILQRPolicy{TQ, TR} <: POMDPs.Policy
+    Q::TQ
+    Qf::TQ
+    R::TR
+    H::Int                                  # planning horizon
+    max_iters::Int
+    u_max::Float64                          # actuator saturation
+    us_warm::Vector{SVector{1,Float64}}     # solver warm start
+end
+
+function ILQRPolicy(;
+        Q  = Diagonal(SVector{2}(10.0, 1.0)),
+        Qf = Diagonal(SVector{2}(50.0, 5.0)),
+        R  = Diagonal(SVector{1}(0.05)),
+        H::Int = 40,
+        max_iters::Int = 8,
+        u_max::Float64 = 100.0)
+    return ILQRPolicy(Q, Qf, R, H, max_iters, u_max, SVector{1,Float64}[])
+end
+
+# ---------------------------------------------------------------------
+# iLQR free functions (take the policy as input)
+# ---------------------------------------------------------------------
+
+function rollout(x0, us, p::ILQRPolicy)
     H = length(us)
-    xs = Vector{Vector{Float64}}(undef, H + 1)
+    xs = Vector{SVector{2,Float64}}(undef, H + 1)
     xs[1] = x0
     for t in 1:H
         xs[t+1] = pendulum_step(xs[t], us[t])
@@ -80,100 +138,180 @@ function rollout(x0::Vector{Float64}, us::Vector{Vector{Float64}})
     return xs
 end
 
-function ilqr_step(x0::Vector{Float64}; H::Int = 20)
-    # Initialize nominal control sequence at zero, roll out, then take
-    # one LQR backward pass on the linearization of that trajectory.
-    us = [zeros(1) for _ in 1:H]
-    xs = rollout(x0, us)
+function trajectory_cost(xs, us, p::ILQRPolicy)
+    c = xs[end]' * p.Qf * xs[end]
+    for t in eachindex(us)
+        c += xs[t]' * p.Q * xs[t] + us[t]' * p.R * us[t]
+    end
+    return c
+end
 
-    # Terminal value
-    Vx  = 2 * Qf * xs[end]
-    Vxx = 2 * Qf
-
+function backward_pass(xs, us, p::ILQRPolicy, μ_reg)
+    H = length(us)
+    Vx  = 2 * p.Qf * xs[end]
+    Vxx = 2 * Matrix(p.Qf)
     K = Vector{Matrix{Float64}}(undef, H)
     k = Vector{Vector{Float64}}(undef, H)
-
     for t in H:-1:1
         x, u = xs[t], us[t]
-        # Jacobians of dynamics at (x, u)
-        fx = ForwardDiff.jacobian(z -> pendulum_step(z, u), x)
-        fu = ForwardDiff.jacobian(z -> pendulum_step(x, z), u)
-
-        # Stage cost derivatives
-        lx  = 2 * Q * x
-        lu  = 2 * R * u
-        lxx = 2 * Q
-        luu = 2 * R
-
-        # Q-function expansion
-        Qx  = lx  + fx' * Vx
-        Qu  = lu  + fu' * Vx
-        Qxx = lxx + fx' * Vxx * fx
-        Quu = luu + fu' * Vxx * fu
+        fx = ForwardDiff.jacobian(z -> pendulum_step(z, u), Vector(x))
+        fu = ForwardDiff.jacobian(z -> pendulum_step(x, z), Vector(u))
+        Qx  = 2 * Vector(p.Q  * x) + fx' * Vx
+        Qu  = 2 * Vector(p.R  * u) + fu' * Vx
+        Qxx = 2 * Matrix(p.Q)      + fx' * Vxx * fx
+        Quu = 2 * Matrix(p.R)      + fu' * Vxx * fu
         Qux = fu' * Vxx * fx
-
-        # Feedback gains
-        Quu_inv = inv(Quu)
+        Quu_inv = inv(Quu + μ_reg * I)
         k[t] = -Quu_inv * Qu
         K[t] = -Quu_inv * Qux
-
-        # Value-function update
         Vx  = Qx + K[t]' * Quu * k[t] + K[t]' * Qu + Qux' * k[t]
         Vxx = Qxx + K[t]' * Quu * K[t] + K[t]' * Qux + Qux' * K[t]
     end
+    return K, k
+end
 
-    # Forward roll of the new control law (no line search).
-    new_us = Vector{Vector{Float64}}(undef, H)
-    new_xs = Vector{Vector{Float64}}(undef, H + 1)
-    new_xs[1] = x0
+function forward_pass(xs, us, K, k, α, p::ILQRPolicy)
+    H = length(us)
+    new_xs = Vector{SVector{2,Float64}}(undef, H + 1)
+    new_us = Vector{SVector{1,Float64}}(undef, H)
+    new_xs[1] = xs[1]
     for t in 1:H
-        new_us[t] = us[t] + k[t] + K[t] * (new_xs[t] - xs[t])
+        u_lin = us[t] + α * SVector{1}(k[t][1]) + SVector{1}(K[t][1,1]*(new_xs[t][1]-xs[t][1]) +
+                                                              K[t][1,2]*(new_xs[t][2]-xs[t][2]))
+        new_us[t] = SVector{1}(clamp(u_lin[1], -p.u_max, p.u_max))
         new_xs[t+1] = pendulum_step(new_xs[t], new_us[t])
     end
-    return new_us
+    return new_xs, new_us
 end
 
-# ----- closed-loop simulation -----
+function ilqr(x0::SVector{2,Float64}, p::ILQRPolicy)
+    us = isempty(p.us_warm) ? [SVector{1}(0.0) for _ in 1:p.H] : copy(p.us_warm)
+    if length(us) != p.H
+        us = [SVector{1}(0.0) for _ in 1:p.H]
+    end
+    xs = rollout(x0, us, p)
+    J  = trajectory_cost(xs, us, p)
+    μ_reg = 1e-3
+    for _ in 1:p.max_iters
+        K, k = backward_pass(xs, us, p, μ_reg)
+        accepted = false
+        α = 1.0
+        for _ in 1:10
+            new_xs, new_us = forward_pass(xs, us, K, k, α, p)
+            J_new = trajectory_cost(new_xs, new_us, p)
+            if J_new < J - 1e-4
+                xs, us = new_xs, new_us
+                J = J_new
+                accepted = true
+                μ_reg = max(μ_reg / 2, 1e-6)
+                break
+            end
+            α *= 0.5
+        end
+        accepted || (μ_reg *= 4)
+        μ_reg > 1e6 && break
+    end
+    return us
+end
+
+# ---------------------------------------------------------------------
+# THE POMDPs.Policy interface — a one-liner.
+# ---------------------------------------------------------------------
+function POMDPs.action(policy::ILQRPolicy, belief::GaussianBelief)
+    us = ilqr(SVector{2}(belief.μ[1], belief.μ[2]), policy)
+    # Shift solution by one step so the next call warm-starts.
+    policy.us_warm = vcat(us[2:end], [SVector{1}(0.0)])
+    return us[1]
+end
+
+# ---------------------------------------------------------------------
+# Build the components
+# ---------------------------------------------------------------------
+
+const W = (σ_proc^2) * Matrix{Float64}(I, 2, 2)
+const V = (σ_obs^2)  * Matrix{Float64}(I, 1, 1)
+
+dmodel = NonlinearDynamicsModel(pendulum_step, W)
+omodel = NonlinearObservationModel(observe_angle, V)
+ekf    = ExtendedKalmanFilter(dmodel, omodel)
+updater = pomdps_updater(ekf)          # wraps the EKF as a POMDPs.Updater
+pomdp   = PendulumPOMDP()
+policy  = ILQRPolicy()
+
+# ---------------------------------------------------------------------
+# Run it via POMDPs.simulate
+# ---------------------------------------------------------------------
 
 rng = MersenneTwister(0)
+hr  = HistoryRecorder(rng = rng, max_steps = 60)
+hist = simulate(hr, pomdp, policy, updater)
 
-# True initial state: a small angle perturbation from upright.
-x_true = [0.3, 0.0]
+# Pull trajectory out of the history for reporting (and downstream
+# plotting, etc).
+angle_history  = [step.s[1] for step in eachstep(hist)]
+push!(angle_history, hist[end].sp[1])              # final state
+belief_history = [step.b for step in eachstep(hist)]
+push!(belief_history, hist[end].bp)                # final belief
+action_history = [step.a[1] for step in eachstep(hist)]
 
-# Initial belief: slightly uncertain prior centered near the true state.
-prior = MvNormal([0.3, 0.0], Matrix(Diagonal([0.05, 0.1])))
-belief = POMDPs.initialize_belief(ekf, prior)
+θ_final = angle_history[end]
+θ_max   = maximum(abs, angle_history)
+steady = angle_history[(2*length(angle_history))÷3 : end]
+θ_ss_mean = sum(steady) / length(steady)
+θ_ss_max  = maximum(abs, steady)
 
-T = 60                       # control steps (60 * dt = 6 s)
-u_prev = [0.0]
-angle_history = Float64[x_true[1]]
-mean_history = [copy(belief.μ)]
+println("Initial angle:                          ", round(angle_history[1], digits=4), " rad")
+println("Final true angle:                       ", round(θ_final, digits=4), " rad")
+println("Max |angle| during run:                 ", round(θ_max, digits=4), " rad")
+println("Steady-state mean |angle| (last third): ", round(abs(θ_ss_mean), digits=4), " rad")
+println("Steady-state max  |angle| (last third): ", round(θ_ss_max, digits=4), " rad")
+println()
+println("Final belief mean (θ, ω):               (",
+        round(belief_history[end].μ[1], digits=4), ", ",
+        round(belief_history[end].μ[2], digits=4), ")")
 
-for t in 1:T
-    global x_true, belief, u_prev
+# ---------------------------------------------------------------------
+# Animation (written to examples/outputs/, which is gitignored)
+# ---------------------------------------------------------------------
+# Set GKSwstype=100 so Plots runs headless. Set GENERATE_GIF=false in
+# the environment to skip rendering.
 
-    # Plan a torque from the certainty-equivalent state.
-    us = ilqr_step(belief.μ)
-    u  = us[1]
+if get(ENV, "GENERATE_GIF", "true") != "false"
+    out_dir = joinpath(@__DIR__, "outputs")
+    mkpath(out_dir)
+    gif_path = joinpath(out_dir, "pendulum_ekf_ilqr.gif")
 
-    # Step the true system (with process noise).
-    x_true = pendulum_step(x_true, u) .+ σ_proc .* randn(rng, 2)
+    anim = @animate for i in 1:length(angle_history)
+        θ_true = angle_history[i]
+        θ_blf  = belief_history[i].μ[1]
 
-    # Observe (with measurement noise).
-    y = observe_angle(x_true, u) .+ σ_obs .* randn(rng, 1)
+        # Pendulum rod: anchored at origin, rod points "up" when θ=0.
+        L = 1.0
+        x_tip_true, y_tip_true = L*sin(θ_true), L*cos(θ_true)
+        x_tip_blf,  y_tip_blf  = L*sin(θ_blf),  L*cos(θ_blf)
 
-    # Belief update via the POMDPs.jl interface.
-    belief = POMDPs.update(ekf, belief, u, y)
+        p1 = plot([0.0, x_tip_true], [0.0, y_tip_true],
+                  lw=4, color=:steelblue, label="true",
+                  xlim=(-1.2, 1.2), ylim=(-0.4, 1.2),
+                  aspect_ratio=:equal, framestyle=:box,
+                  title="Pendulum (step $(i-1)/$(length(angle_history)-1))")
+        plot!(p1, [0.0, x_tip_blf], [0.0, y_tip_blf],
+              lw=2, color=:orange, linestyle=:dash, label="belief")
+        scatter!(p1, [0.0], [0.0], color=:black, ms=4, label=false)
+        scatter!(p1, [x_tip_true], [y_tip_true], color=:steelblue, ms=6, label=false)
 
-    push!(angle_history, x_true[1])
-    push!(mean_history, copy(belief.μ))
-    u_prev = u
+        p2 = plot(0:(i-1), angle_history[1:i],
+                  color=:steelblue, lw=2, label="θ true",
+                  xlim=(0, length(angle_history)-1), ylim=(-1.0, 1.0),
+                  xlabel="step", ylabel="θ (rad)",
+                  legend=:topright)
+        plot!(p2, 0:(i-1), [b.μ[1] for b in belief_history[1:i]],
+              color=:orange, lw=2, linestyle=:dash, label="θ belief")
+        hline!(p2, [0.0], color=:gray, linestyle=:dot, label=false)
+
+        plot(p1, p2, layout=(1, 2), size=(900, 400))
+    end
+    gif(anim, gif_path, fps=10)
+    println()
+    println("Animation saved to: $gif_path")
 end
-
-θf = angle_history[end]
-ωf = mean_history[end][2]
-println("Final true angle:        ", round(θf, digits=4), " rad")
-println("Final belief mean (θ,ω): (",
-        round(mean_history[end][1], digits=4), ", ",
-        round(ωf, digits=4), ")")
-println("Max |angle| over run:    ", round(maximum(abs, angle_history), digits=4), " rad")

--- a/examples/pendulum_ekf_ilqr.jl
+++ b/examples/pendulum_ekf_ilqr.jl
@@ -6,6 +6,13 @@
 # `ILQRPolicy` that runs iterative LQR on the belief mean (certainty
 # equivalence — iLQR ignores belief covariance). The closed loop is
 # driven by `POMDPs.simulate`, not a hand-rolled control loop.
+#
+# The observation is the angular velocity ω only (gyroscope-style);
+# the angle θ is hidden and must be inferred. This is the more
+# pedagogically interesting filtering problem: the controller acts on
+# `belief.μ[1]` for the angle even though the angle is never directly
+# observed. The animation shows σθ shrinking over time (the filter
+# converging) while σω stays small throughout (direct observation).
 
 using GaussianFilters
 using POMDPs
@@ -49,15 +56,19 @@ function pendulum_step(x::AbstractVector, u::AbstractVector)
                       w + alph*IP.dt)
 end
 
-# Observe the angle only; angular velocity must be inferred by the EKF.
-observe_angle(x::AbstractVector, u::AbstractVector) = SVector{1}(x[1])
+# Observe the angular velocity only (gyroscope-like measurement). The
+# angle itself must be inferred by the EKF — there is no direct
+# observation of absolute position. This is the more pedagogically
+# interesting variant: the controller acts on belief.μ for θ, which
+# is reconstructed entirely from successive ω observations.
+observe_omega(x::AbstractVector, u::AbstractVector) = SVector{1}(x[2])
 
 # ---------------------------------------------------------------------
 # POMDP definition
 # ---------------------------------------------------------------------
 
 const σ_proc = 0.01    # process noise std (per state component)
-const σ_obs  = 0.05    # angle observation noise std (rad)
+const σ_obs  = 0.1     # angular velocity observation noise std (rad/s)
 
 struct PendulumPOMDP <: POMDP{SVector{2,Float64}, SVector{1,Float64}, SVector{1,Float64}}
     σ_proc::Float64
@@ -93,7 +104,7 @@ POMDPs.discount(p::PendulumPOMDP) = p.γ
 # accommodates POMDPs' internal handling.
 function POMDPs.gen(p::PendulumPOMDP, s::AbstractVector, a::AbstractVector, rng)
     sp = pendulum_step(s, a) .+ p.σ_proc .* SVector{2}(randn(rng), randn(rng))
-    o  = observe_angle(sp, a) .+ p.σ_obs .* SVector{1}(randn(rng))
+    o  = observe_omega(sp, a) .+ p.σ_obs .* SVector{1}(randn(rng))
     r  = -(s[1]^2 + 0.1*s[2]^2 + 0.01*a[1]^2)
     return (sp = sp, o = o, r = r)
 end
@@ -232,7 +243,7 @@ const W = (σ_proc^2) * Matrix{Float64}(I, 2, 2)
 const V = (σ_obs^2)  * Matrix{Float64}(I, 1, 1)
 
 dmodel = NonlinearDynamicsModel(pendulum_step, W)
-omodel = NonlinearObservationModel(observe_angle, V)
+omodel = NonlinearObservationModel(observe_omega, V)
 ekf    = ExtendedKalmanFilter(dmodel, omodel)
 updater = pomdps_updater(ekf)          # wraps the EKF as a POMDPs.Updater
 pomdp   = PendulumPOMDP()
@@ -250,6 +261,8 @@ hist = simulate(hr, pomdp, policy, updater)
 # plotting, etc).
 angle_history  = [step.s[1] for step in eachstep(hist)]
 push!(angle_history, hist[end].sp[1])              # final state
+omega_history  = [step.s[2] for step in eachstep(hist)]
+push!(omega_history, hist[end].sp[2])
 belief_history = [step.b for step in eachstep(hist)]
 push!(belief_history, hist[end].bp)                # final belief
 action_history = [step.a[1] for step in eachstep(hist)]
@@ -281,11 +294,18 @@ if get(ENV, "GENERATE_GIF", "true") != "false"
     mkpath(out_dir)
     gif_path = joinpath(out_dir, "pendulum_ekf_ilqr.gif")
 
-    anim = @animate for i in 1:length(angle_history)
+    N = length(angle_history)
+    # Pre-compute belief mean and ±2σ envelopes over the full run.
+    μθ = [b.μ[1] for b in belief_history]
+    μω = [b.μ[2] for b in belief_history]
+    σθ = [2*sqrt(b.Σ[1,1]) for b in belief_history]
+    σω = [2*sqrt(b.Σ[2,2]) for b in belief_history]
+
+    anim = @animate for i in 1:N
         θ_true = angle_history[i]
         θ_blf  = belief_history[i].μ[1]
 
-        # Pendulum rod: anchored at origin, rod points "up" when θ=0.
+        # --- left: pendulum rod animation ---
         L = 1.0
         x_tip_true, y_tip_true = L*sin(θ_true), L*cos(θ_true)
         x_tip_blf,  y_tip_blf  = L*sin(θ_blf),  L*cos(θ_blf)
@@ -294,22 +314,40 @@ if get(ENV, "GENERATE_GIF", "true") != "false"
                   lw=4, color=:steelblue, label="true",
                   xlim=(-1.2, 1.2), ylim=(-0.4, 1.2),
                   aspect_ratio=:equal, framestyle=:box,
-                  title="Pendulum (step $(i-1)/$(length(angle_history)-1))")
+                  title="Pendulum (step $(i-1)/$(N-1))")
         plot!(p1, [0.0, x_tip_blf], [0.0, y_tip_blf],
               lw=2, color=:orange, linestyle=:dash, label="belief")
         scatter!(p1, [0.0], [0.0], color=:black, ms=4, label=false)
         scatter!(p1, [x_tip_true], [y_tip_true], color=:steelblue, ms=6, label=false)
 
-        p2 = plot(0:(i-1), angle_history[1:i],
-                  color=:steelblue, lw=2, label="θ true",
-                  xlim=(0, length(angle_history)-1), ylim=(-1.0, 1.0),
-                  xlabel="step", ylabel="θ (rad)",
-                  legend=:topright)
-        plot!(p2, 0:(i-1), [b.μ[1] for b in belief_history[1:i]],
-              color=:orange, lw=2, linestyle=:dash, label="θ belief")
+        # --- top right: θ over time with belief ±2σ ribbon ---
+        ts = 0:(i-1)
+        p2 = plot(ts, μθ[1:i], ribbon=σθ[1:i],
+                  color=:orange, lw=2, fillalpha=0.25,
+                  label="belief μ ± 2σ",
+                  xlim=(0, N-1), ylim=(-1.0, 1.0),
+                  ylabel="θ (rad)", legend=:topright,
+                  guidefonthalign=:right, ymirror=false,
+                  left_margin=8Plots.mm)
+        plot!(p2, ts, angle_history[1:i],
+              color=:steelblue, lw=2, label="θ true")
         hline!(p2, [0.0], color=:gray, linestyle=:dot, label=false)
 
-        plot(p1, p2, layout=(1, 2), size=(900, 400))
+        # --- bottom right: ω over time with belief ±2σ ribbon ---
+        p3 = plot(ts, μω[1:i], ribbon=σω[1:i],
+                  color=:orange, lw=2, fillalpha=0.25,
+                  label="belief μ ± 2σ",
+                  xlim=(0, N-1), ylim=(-3.0, 3.0),
+                  xlabel="step", ylabel="ω (rad/s)", legend=:topright,
+                  guidefonthalign=:right,
+                  left_margin=8Plots.mm, bottom_margin=8Plots.mm)
+        plot!(p3, ts, omega_history[1:i],
+              color=:steelblue, lw=2, label="ω true (observed)")
+        hline!(p3, [0.0], color=:gray, linestyle=:dot, label=false)
+
+        right = plot(p2, p3, layout=(2, 1))
+        plot(p1, right, layout=(1, 2), size=(1100, 550),
+             bottom_margin=5Plots.mm)
     end
     gif(anim, gif_path, fps=10)
     println()

--- a/examples/pendulum_ekf_ilqr.jl
+++ b/examples/pendulum_ekf_ilqr.jl
@@ -1,0 +1,179 @@
+# Stabilizing a noisy inverted pendulum from partial observations
+# ================================================================
+#
+# Demonstrates the GaussianFilters <-> POMDPs.jl integration in a closed
+# control loop. At each step we
+#   1. observe a noisy angle (the angular velocity is hidden),
+#   2. update the EKF belief via POMDPs.update,
+#   3. plan a torque sequence with iLQR using belief.μ as the starting
+#      state (certainty equivalent control — iLQR ignores belief.Σ),
+#   4. apply the first planned action.
+#
+# The dynamics are pulled from POMDPModels.InvertedPendulum so we are
+# integrating against the real ecosystem rather than a private copy.
+
+using GaussianFilters
+using POMDPs
+using POMDPModels: InvertedPendulum
+using LinearAlgebra
+using Random
+using ForwardDiff
+using Distributions: MvNormal
+
+# ----- dynamics & observation models -----
+#
+# We pull parameters from POMDPModels.InvertedPendulum and re-implement
+# the Euler step generically (the POMDPModels.euler signature pins state
+# to Tuple{Float64,Float64}, which blocks ForwardDiff dual numbers).
+
+const ip = InvertedPendulum()
+const σ_proc = 0.01    # process noise std per state component
+const σ_obs  = 0.05    # angle observation noise std (rad)
+
+function dwdt(th, w, u, m=ip)
+    num = m.g*sin(th) - m.alpha*m.m*m.l*(w^2)*sin(2*th)*0.5 - m.alpha*cos(th)*u
+    den = (4/3)*m.l - m.alpha*m.l*(cos(th)^2)
+    return num/den
+end
+
+function pendulum_step(x::AbstractVector, u::AbstractVector)
+    th, w, ut = x[1], x[2], u[1]
+    alph = dwdt(th, w, ut)
+    return [th + w*ip.dt + 0.5*alph*ip.dt^2,
+            w + alph*ip.dt]
+end
+
+# Observation: noisy measurement of the angle only.
+observe_angle(x::AbstractVector, u::AbstractVector) = [x[1]]
+
+W = σ_proc^2 * Matrix{Float64}(I, 2, 2)
+V = (σ_obs^2)  * Matrix{Float64}(I, 1, 1)
+
+dmodel = NonlinearDynamicsModel(pendulum_step, W)
+omodel = NonlinearObservationModel(observe_angle, V)
+ekf = ExtendedKalmanFilter(dmodel, omodel)
+
+# ----- minimal iLQR -----
+#
+# Standard LQR backward pass on the linearization of pendulum_step around
+# the current nominal trajectory, with a quadratic stage cost
+#
+#   ℓ(x,u) = xᵀ Q x + uᵀ R u
+#
+# and quadratic terminal cost xᵀ Qf x. We linearize via ForwardDiff at
+# every step of the forward roll, do one backward LQR sweep to compute
+# feedback gains, and return the resulting control sequence. No line
+# search, no regularization — sufficient to stabilize from a small
+# perturbation (θ₀ ~ 0.3) but not to swing up from θ = π.
+
+const Q  = Diagonal([10.0, 1.0])        # stage cost on (θ, ω)
+const Qf = Diagonal([100.0, 10.0])      # terminal cost
+const R  = Diagonal([0.01])             # control effort
+
+function rollout(x0::Vector{Float64}, us::Vector{Vector{Float64}})
+    H = length(us)
+    xs = Vector{Vector{Float64}}(undef, H + 1)
+    xs[1] = x0
+    for t in 1:H
+        xs[t+1] = pendulum_step(xs[t], us[t])
+    end
+    return xs
+end
+
+function ilqr_step(x0::Vector{Float64}; H::Int = 20)
+    # Initialize nominal control sequence at zero, roll out, then take
+    # one LQR backward pass on the linearization of that trajectory.
+    us = [zeros(1) for _ in 1:H]
+    xs = rollout(x0, us)
+
+    # Terminal value
+    Vx  = 2 * Qf * xs[end]
+    Vxx = 2 * Qf
+
+    K = Vector{Matrix{Float64}}(undef, H)
+    k = Vector{Vector{Float64}}(undef, H)
+
+    for t in H:-1:1
+        x, u = xs[t], us[t]
+        # Jacobians of dynamics at (x, u)
+        fx = ForwardDiff.jacobian(z -> pendulum_step(z, u), x)
+        fu = ForwardDiff.jacobian(z -> pendulum_step(x, z), u)
+
+        # Stage cost derivatives
+        lx  = 2 * Q * x
+        lu  = 2 * R * u
+        lxx = 2 * Q
+        luu = 2 * R
+
+        # Q-function expansion
+        Qx  = lx  + fx' * Vx
+        Qu  = lu  + fu' * Vx
+        Qxx = lxx + fx' * Vxx * fx
+        Quu = luu + fu' * Vxx * fu
+        Qux = fu' * Vxx * fx
+
+        # Feedback gains
+        Quu_inv = inv(Quu)
+        k[t] = -Quu_inv * Qu
+        K[t] = -Quu_inv * Qux
+
+        # Value-function update
+        Vx  = Qx + K[t]' * Quu * k[t] + K[t]' * Qu + Qux' * k[t]
+        Vxx = Qxx + K[t]' * Quu * K[t] + K[t]' * Qux + Qux' * K[t]
+    end
+
+    # Forward roll of the new control law (no line search).
+    new_us = Vector{Vector{Float64}}(undef, H)
+    new_xs = Vector{Vector{Float64}}(undef, H + 1)
+    new_xs[1] = x0
+    for t in 1:H
+        new_us[t] = us[t] + k[t] + K[t] * (new_xs[t] - xs[t])
+        new_xs[t+1] = pendulum_step(new_xs[t], new_us[t])
+    end
+    return new_us
+end
+
+# ----- closed-loop simulation -----
+
+rng = MersenneTwister(0)
+
+# True initial state: a small angle perturbation from upright.
+x_true = [0.3, 0.0]
+
+# Initial belief: slightly uncertain prior centered near the true state.
+prior = MvNormal([0.3, 0.0], Matrix(Diagonal([0.05, 0.1])))
+belief = POMDPs.initialize_belief(ekf, prior)
+
+T = 60                       # control steps (60 * dt = 6 s)
+u_prev = [0.0]
+angle_history = Float64[x_true[1]]
+mean_history = [copy(belief.μ)]
+
+for t in 1:T
+    global x_true, belief, u_prev
+
+    # Plan a torque from the certainty-equivalent state.
+    us = ilqr_step(belief.μ)
+    u  = us[1]
+
+    # Step the true system (with process noise).
+    x_true = pendulum_step(x_true, u) .+ σ_proc .* randn(rng, 2)
+
+    # Observe (with measurement noise).
+    y = observe_angle(x_true, u) .+ σ_obs .* randn(rng, 1)
+
+    # Belief update via the POMDPs.jl interface.
+    belief = POMDPs.update(ekf, belief, u, y)
+
+    push!(angle_history, x_true[1])
+    push!(mean_history, copy(belief.μ))
+    u_prev = u
+end
+
+θf = angle_history[end]
+ωf = mean_history[end][2]
+println("Final true angle:        ", round(θf, digits=4), " rad")
+println("Final belief mean (θ,ω): (",
+        round(mean_history[end][1], digits=4), ", ",
+        round(ωf, digits=4), ")")
+println("Max |angle| over run:    ", round(maximum(abs, angle_history), digits=4), " rad")

--- a/examples/pomdps_integration.jl
+++ b/examples/pomdps_integration.jl
@@ -1,0 +1,37 @@
+using GaussianFilters
+using POMDPs
+using LinearAlgebra
+using Random
+
+# This example shows that a GaussianFilters.AbstractFilter doubles as a
+# POMDPs.jl belief updater. Once POMDPs is loaded, the package extension
+# wires up POMDPs.update(filter, b, a, o) -> GaussianFilters.update(...).
+
+# A simple linear system: position-velocity 1D motion observed in position.
+dt = 0.1
+A = [1.0 dt; 0.0 1.0]
+B = reshape([0.0, dt], 2, 1)
+W = 0.01 * Matrix{Float64}(I, 2, 2)
+dmodel = LinearDynamicsModel(A, B, W)
+
+C = [1.0 0.0]
+V = 0.05 * Matrix{Float64}(I, 1, 1)
+omodel = LinearObservationModel(C, V)
+
+kf = KalmanFilter(dmodel, omodel)
+b0 = GaussianBelief([0.0, 0.0], Matrix{Float64}(I, 2, 2))
+
+# Simulate a few steps so we have an action/observation history.
+rng = MersenneTwister(0)
+sim_states, sim_observations = simulation(kf, b0, [[1.0] for _ in 1:5], rng)
+
+# Use POMDPs.update (which dispatches to GaussianFilters.update through
+# the package extension) to filter the observations.
+belief = POMDPs.initialize_belief(kf, b0)
+for (a, o) in zip([[1.0] for _ in 1:5], sim_observations)
+    global belief = POMDPs.update(kf, belief, a, o)
+end
+
+println("Final belief mean: ", belief.μ)
+println("Final belief covariance: ")
+display(belief.Σ)

--- a/ext/GaussianFiltersPOMDPsExt.jl
+++ b/ext/GaussianFiltersPOMDPsExt.jl
@@ -1,0 +1,14 @@
+module GaussianFiltersPOMDPsExt
+
+using GaussianFilters
+using POMDPs
+
+# A GaussianFilters AbstractFilter doubles as a POMDPs.Updater. The two
+# update signatures already agree on argument order: (b_prev, a, o).
+POMDPs.update(f::AbstractFilter, b::GaussianBelief, a::AbstractVector, o::AbstractVector) =
+    GaussianFilters.update(f, b, a, o)
+
+# Pass-through initialize_belief for callers who hold a GaussianBelief.
+POMDPs.initialize_belief(::AbstractFilter, b::GaussianBelief) = b
+
+end # module

--- a/ext/GaussianFiltersPOMDPsExt.jl
+++ b/ext/GaussianFiltersPOMDPsExt.jl
@@ -2,13 +2,17 @@ module GaussianFiltersPOMDPsExt
 
 using GaussianFilters
 using POMDPs
+using Distributions: AbstractMvNormal, mean, cov
 
 # A GaussianFilters AbstractFilter doubles as a POMDPs.Updater. The two
 # update signatures already agree on argument order: (b_prev, a, o).
 POMDPs.update(f::AbstractFilter, b::GaussianBelief, a::AbstractVector, o::AbstractVector) =
     GaussianFilters.update(f, b, a, o)
 
-# Pass-through initialize_belief for callers who hold a GaussianBelief.
+# Initialize from a GaussianBelief (identity) or from any multivariate
+# normal distribution (extract mean and covariance).
 POMDPs.initialize_belief(::AbstractFilter, b::GaussianBelief) = b
+POMDPs.initialize_belief(::AbstractFilter, d::AbstractMvNormal) =
+    GaussianBelief(mean(d), cov(d))
 
 end # module

--- a/ext/GaussianFiltersPOMDPsExt.jl
+++ b/ext/GaussianFiltersPOMDPsExt.jl
@@ -4,15 +4,48 @@ using GaussianFilters
 using POMDPs
 using Distributions: AbstractMvNormal, mean, cov
 
-# A GaussianFilters AbstractFilter doubles as a POMDPs.Updater. The two
-# update signatures already agree on argument order: (b_prev, a, o).
+# Two integration patterns are supported:
+#
+# 1) Direct dispatch on AbstractFilter — convenient when you just want
+#    POMDPs.update(filter, b, a, o) without going through the full
+#    POMDPs.simulate machinery.
+#
+# 2) A GaussianFilterUpdater wrapper subtyping POMDPs.Updater — needed
+#    by simulators (HistoryRecorder, RolloutSimulator) that dispatch on
+#    the Updater abstract type.
+
+# --- direct AbstractFilter methods ---
+
 POMDPs.update(f::AbstractFilter, b::GaussianBelief, a::AbstractVector, o::AbstractVector) =
     GaussianFilters.update(f, b, a, o)
 
-# Initialize from a GaussianBelief (identity) or from any multivariate
-# normal distribution (extract mean and covariance).
 POMDPs.initialize_belief(::AbstractFilter, b::GaussianBelief) = b
 POMDPs.initialize_belief(::AbstractFilter, d::AbstractMvNormal) =
     GaussianBelief(mean(d), cov(d))
+
+# --- POMDPs.Updater wrapper ---
+
+"""
+    GaussianFilterUpdater(filter::AbstractFilter)
+
+A `POMDPs.Updater` wrapper around any GaussianFilters `AbstractFilter`.
+Use this when handing a Gaussian-filter belief updater to a POMDPs.jl
+simulator that requires `<:Updater` dispatch
+(`HistoryRecorder`, `RolloutSimulator`, etc).
+"""
+struct GaussianFilterUpdater{F<:AbstractFilter} <: POMDPs.Updater
+    filter::F
+end
+
+POMDPs.update(u::GaussianFilterUpdater, b::GaussianBelief, a::AbstractVector, o::AbstractVector) =
+    GaussianFilters.update(u.filter, b, a, o)
+
+POMDPs.initialize_belief(::GaussianFilterUpdater, b::GaussianBelief) = b
+POMDPs.initialize_belief(::GaussianFilterUpdater, d::AbstractMvNormal) =
+    GaussianBelief(mean(d), cov(d))
+
+# Make the wrapper reachable from a `using GaussianFilters` context by
+# overloading a stub function defined in the main package.
+GaussianFilters.pomdps_updater(f::AbstractFilter) = GaussianFilterUpdater(f)
 
 end # module

--- a/src/GaussianFilters.jl
+++ b/src/GaussianFilters.jl
@@ -77,4 +77,18 @@ export
 	belief_ellipse
 include("utils.jl")
 
+# POMDPs.jl integration stub. The actual implementation lives in
+# ext/GaussianFiltersPOMDPsExt.jl and overrides this when POMDPs is
+# loaded. The stub errors with a helpful message otherwise.
+"""
+    pomdps_updater(filter::AbstractFilter)
+
+Wrap a GaussianFilters filter in a `POMDPs.Updater` so it can be passed
+to POMDPs.jl simulators like `HistoryRecorder`. Requires POMDPs.jl to
+be loaded; the implementation lives in a package extension.
+"""
+function pomdps_updater end
+
+export pomdps_updater
+
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -70,4 +70,8 @@ end
     @time @testset "StaticArrays Compatibility" begin
         include(joinpath(testdir, "test_static.jl"))
     end
+
+    @time @testset "POMDPs.jl Interface" begin
+        include(joinpath(testdir, "test_pomdps.jl"))
+    end
 end

--- a/test/test_pomdps.jl
+++ b/test/test_pomdps.jl
@@ -1,4 +1,5 @@
 using POMDPs
+using Distributions: MvNormal
 
 @testset "POMDPs.update extension" begin
     dt = 0.1
@@ -24,4 +25,11 @@ using POMDPs
 
     # initialize_belief should be the identity on a GaussianBelief
     @test POMDPs.initialize_belief(kf, b0) === b0
+
+    # initialize_belief from an MvNormal extracts mean and covariance
+    d = MvNormal([1.0, 2.0], [4.0 0.0; 0.0 9.0])
+    b_from_d = POMDPs.initialize_belief(kf, d)
+    @test b_from_d isa GaussianBelief
+    @test b_from_d.μ == [1.0, 2.0]
+    @test b_from_d.Σ == [4.0 0.0; 0.0 9.0]
 end

--- a/test/test_pomdps.jl
+++ b/test/test_pomdps.jl
@@ -32,4 +32,17 @@ using Distributions: MvNormal
     @test b_from_d isa GaussianBelief
     @test b_from_d.μ == [1.0, 2.0]
     @test b_from_d.Σ == [4.0 0.0; 0.0 9.0]
+
+    # pomdps_updater wraps the filter as a POMDPs.Updater subtype
+    upd = pomdps_updater(kf)
+    @test upd isa POMDPs.Updater
+    b_via_upd = POMDPs.update(upd, b0, a, o)
+    @test b_via_upd.μ == b_native.μ
+    @test b_via_upd.Σ == b_native.Σ
+
+    # initialize_belief through the wrapper works too
+    @test POMDPs.initialize_belief(upd, b0) === b0
+    b_wrapped = POMDPs.initialize_belief(upd, d)
+    @test b_wrapped isa GaussianBelief
+    @test b_wrapped.μ == [1.0, 2.0]
 end

--- a/test/test_pomdps.jl
+++ b/test/test_pomdps.jl
@@ -1,0 +1,27 @@
+using POMDPs
+
+@testset "POMDPs.update extension" begin
+    dt = 0.1
+    A = [1.0 dt; 0.0 1.0]
+    B = [0.0; dt][:, :]
+    W = 0.01 * Matrix{Float64}(I, 2, 2)
+    dmodel = LinearDynamicsModel(A, B, W)
+
+    C = [1.0 0.0]
+    V = 0.1 * Matrix{Float64}(I, 1, 1)
+    omodel = LinearObservationModel(C, V)
+
+    kf = KalmanFilter(dmodel, omodel)
+    b0 = GaussianBelief([0.0, 0.0], Matrix{Float64}(I, 2, 2))
+
+    # POMDPs.update should produce the same result as GaussianFilters.update
+    a = [1.0]
+    o = [0.5]
+    b_pomdps = POMDPs.update(kf, b0, a, o)
+    b_native = GaussianFilters.update(kf, b0, a, o)
+    @test b_pomdps.μ == b_native.μ
+    @test b_pomdps.Σ == b_native.Σ
+
+    # initialize_belief should be the identity on a GaussianBelief
+    @test POMDPs.initialize_belief(kf, b0) === b0
+end


### PR DESCRIPTION
Closes #38

Adds a POMDPs.jl package extension (weak dependency, requires Julia 1.9+) that wires GaussianFilters' `AbstractFilter` into the POMDPs belief-updater interface.

**Extension surface (`ext/GaussianFiltersPOMDPsExt.jl`):**

- `POMDPs.update(filter, b, a, o)` dispatches directly on `AbstractFilter` — convenient for simple integrations.
- `POMDPs.initialize_belief` accepts either a `GaussianBelief` (identity) or any `AbstractMvNormal` (extracts mean and cov).
- `GaussianFilterUpdater <: POMDPs.Updater` wrapper for simulators that dispatch on the abstract type (`HistoryRecorder`, `RolloutSimulator`, etc).
- `pomdps_updater(filter)` builder, exported as a stub from the main package and given a real implementation in the extension.

Users who do not have POMDPs.jl loaded pay zero overhead — the extension only activates when both packages are present.

**Two example scripts:**

- `examples/pomdps_integration.jl` — minimal demonstration of using a `KalmanFilter` through `POMDPs.update`.
- `examples/pendulum_ekf_ilqr.jl` — closed-loop stabilization of a noisy inverted pendulum observed only through its angular velocity (gyroscope-style). Defines a `PendulumPOMDP` (with `SVector` state/action/observation, exercising the StaticArrays support from #58), an `ILQRPolicy <: POMDPs.Policy` that runs iterative LQR on the belief mean (certainty-equivalent control), wraps the EKF with `pomdps_updater`, and drives the whole closed loop through `POMDPs.simulate` via `HistoryRecorder`.

The iLQR implementation includes backward pass with Levenberg-Marquardt regularization, backtracking line search, and actuator saturation — about 80 lines. The pendulum dynamics are pulled from `POMDPModels.InvertedPendulum` (parameters) but re-expressed generically so ForwardDiff dual numbers can pass through them (the original `euler` signature pins state to `Tuple{Float64,Float64}`).

The example produces an animation of the closed-loop trajectory with belief mean ± 2σ ribbons on both θ and ω.

Bumps julia compat to 1.9 to enable `[weakdeps]` and `[extensions]`. Adds `POMDPs` to test deps and adds a `test/test_pomdps.jl` regression covering both the direct-dispatch and `GaussianFilterUpdater`-wrapper paths.
