### PR TITLE
docs: migrate to Documenter 1.x, surface missing docstrings, add Documentation workflow

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,37 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+      - master
+    tags: '*'
+  pull_request:
+
+jobs:
+  build:
+    # These permissions are needed to:
+    # - Deploy the documentation: https://documenter.juliadocs.org/stable/man/hosting/#Permissions
+    # - Delete old caches: https://github.com/julia-actions/cache#usage
+    permissions:
+      actions: write
+      contents: write
+      pull-requests: read
+      statuses: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: '1'
+      - uses: julia-actions/cache@v2
+      - name: Install dependencies
+        shell: julia --color=yes --project=docs {0}
+        run: |
+          using Pkg
+          Pkg.develop(PackageSpec(path=pwd()))
+          Pkg.instantiate()
+      - name: Build and deploy
+        run: julia --color=yes --project=docs docs/make.jl
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # If authenticating with GitHub Actions token
+          # DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # If authenticating with SSH deploy key

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,2 +1,6 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+GaussianFilters = "08d575fb-911d-541e-8431-6cfa767e7851"
+
+[sources]
+GaussianFilters = {path = ".."}

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -3,8 +3,9 @@ using Documenter, GaussianFilters
 # This function builds the documentation
 makedocs(
     modules   = [GaussianFilters],
-    format    = :html,
+    format    = Documenter.HTML(),
     sitename  = "GaussianFilters",
+    warnonly  = [:docs_block, :missing_docs],
     pages     = ["Introduction" => [
                     "Basics" => "index.md",
                     "Installation" => "install.md"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -12,6 +12,9 @@ makedocs(
                 "User Documentation" => [
                     "Kalman-class Filters" => "kalman.md",
                     "GM-PHD Filter" => "gmphd.md"
+                    ],
+                "Integrations" => [
+                    "POMDPs.jl" => "pomdps.md"
                     ]
                 ])
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -5,7 +5,6 @@ makedocs(
     modules   = [GaussianFilters],
     format    = Documenter.HTML(),
     sitename  = "GaussianFilters",
-    warnonly  = [:docs_block, :missing_docs],
     pages     = ["Introduction" => [
                     "Basics" => "index.md",
                     "Installation" => "install.md"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,9 +1,8 @@
 using Documenter, GaussianFilters
 
-# This function builds the documentation
 makedocs(
     modules   = [GaussianFilters],
-    format    = Documenter.HTML(),
+    format    = Documenter.HTML(; prettyurls = get(ENV, "CI", "false") == "true"),
     sitename  = "GaussianFilters",
     pages     = ["Introduction" => [
                     "Basics" => "index.md",
@@ -18,6 +17,9 @@ makedocs(
                     ]
                 ])
 
-deploydocs(
-    repo = "github.com/sisl/GaussianFilters.jl",
-)
+if get(ENV, "CI", "false") == "true"
+    deploydocs(;
+        repo = "github.com/sisl/GaussianFilters.jl",
+        push_preview = true,
+    )
+end

--- a/docs/src/gmphd.md
+++ b/docs/src/gmphd.md
@@ -31,11 +31,18 @@ GaussianFilters.PHDFilter
 Currently, the GM-PHD Filter must be run step-by-step. Similar to the Kalman-Class filters, this can be done with a single call to `update`, which wraps functions to `predict` the next state, perform a measurement update with `measure`, and `prune` the resulting mixture model of low-probability and sufficiently close mixtures.
 
 ```@docs
-GaussianFilters.update
-GaussianFilters.predict
-GaussianFilters.measure
+update(::PHDFilter, ::GaussianMixture, ::Vector{<:AbstractVector{<:Number}}, ::Real, ::Real, ::Integer)
+predict(::PHDFilter, ::GaussianMixture)
+measure(::PHDFilter, ::GaussianMixture, ::Vector{<:AbstractVector{<:Real}})
 GaussianFilters.prune
 ```
+
+The GM-PHD update internally evaluates a multivariate normal density:
+
+```@docs
+GaussianFilters.MvNormalPDF
+```
+
 Target locations can be extracted from a `GaussianMixture` state using `multiple_target_state_extraction`.
 
 ```@docs
@@ -44,8 +51,8 @@ GaussianFilters.multiple_target_state_extraction
 
 ## Examples
 
-Full implementation examples can be found in the `notebooks` folder of the repo:
+Full implementation examples can be found in the [`examples/`](https://github.com/sisl/GaussianFilters.jl/tree/master/examples) directory of the repo:
 
-[GM-PHD Object Surveillance Example](https://github.com/sisl/GaussianFilters.jl/blob/master/notebooks/GMPHD_SurveillanceExample.ipynb)
-
-[GM-PHD Aircraft Carrier Example](https://github.com/sisl/GaussianFilters.jl/blob/master/notebooks/GMPHD_AircraftCarrierExample.ipynb)
+- [`gmphd_surveillance.jl`](https://github.com/sisl/GaussianFilters.jl/blob/master/examples/gmphd_surveillance.jl) — Object Surveillance
+- [`gmphd_aircraft_carrier.jl`](https://github.com/sisl/GaussianFilters.jl/blob/master/examples/gmphd_aircraft_carrier.jl) — Aircraft Carrier scenario
+- [`gmphd_tests.jl`](https://github.com/sisl/GaussianFilters.jl/blob/master/examples/gmphd_tests.jl) — Visualization helpers

--- a/docs/src/kalman.md
+++ b/docs/src/kalman.md
@@ -95,6 +95,21 @@ GaussianFilters.unpack
 GaussianFilters.belief_ellipse
 ```
 
+## POMDPs.jl integration
+
+When [POMDPs.jl](https://github.com/JuliaPOMDP/POMDPs.jl) is also
+loaded, a package extension wires GaussianFilters' `AbstractFilter`
+into the POMDPs belief-updater interface. Use `pomdps_updater` to
+obtain a `POMDPs.Updater` wrapper suitable for `POMDPs.simulate` and
+related simulators.
+
+```@docs
+GaussianFilters.pomdps_updater
+```
+
+See `examples/pomdps_integration.jl` and `examples/pendulum_ekf_ilqr.jl`
+for end-to-end usage.
+
 ## Examples
 
 Full implementation examples can be found in the [`examples/`](https://github.com/sisl/GaussianFilters.jl/tree/master/examples) directory of the repo:
@@ -102,3 +117,5 @@ Full implementation examples can be found in the [`examples/`](https://github.co
 - [`kf_2d_motion.jl`](https://github.com/sisl/GaussianFilters.jl/blob/master/examples/kf_2d_motion.jl) — Kalman Filter
 - [`ekf_spinning_satellite.jl`](https://github.com/sisl/GaussianFilters.jl/blob/master/examples/ekf_spinning_satellite.jl) — Extended Kalman Filter
 - [`ukf_nonholonomic_robot.jl`](https://github.com/sisl/GaussianFilters.jl/blob/master/examples/ukf_nonholonomic_robot.jl) — Unscented Kalman Filter
+- [`pomdps_integration.jl`](https://github.com/sisl/GaussianFilters.jl/blob/master/examples/pomdps_integration.jl) — KF used through `POMDPs.update`
+- [`pendulum_ekf_ilqr.jl`](https://github.com/sisl/GaussianFilters.jl/blob/master/examples/pendulum_ekf_ilqr.jl) — EKF + iLQR closed loop driven by `POMDPs.simulate`

--- a/docs/src/kalman.md
+++ b/docs/src/kalman.md
@@ -8,6 +8,7 @@ The Kalman, Extended Kalman, and Unscented Kalman filters are used to estimate s
 
 ```@docs
 GaussianFilters.GaussianBelief
+GaussianFilters.AbstractFilter
 ```
 
 ## Building a Filter
@@ -17,6 +18,8 @@ In general, Kalman-class filters can be built with either linear or non-linear d
 NOTE: There is no need to define Jacobians for non-linear models, since this package uses automatic forward differentiation to compute Jacobians in real time. Just make sure the models are forward differentiable in all possible belief locations.
 
 ```@docs
+GaussianFilters.DynamicsModel
+GaussianFilters.ObservationModel
 GaussianFilters.LinearDynamicsModel
 GaussianFilters.LinearObservationModel
 GaussianFilters.NonlinearDynamicsModel
@@ -31,6 +34,13 @@ GaussianFilters.ExtendedKalmanFilter
 GaussianFilters.UnscentedKalmanFilter
 ```
 
+The UKF additionally exposes the sigma-point machinery used internally:
+
+```@docs
+GaussianFilters.unscented_transform
+GaussianFilters.unscented_transform_inverse
+```
+
 
 ## Simulating Data
 
@@ -43,11 +53,11 @@ GaussianFilters.simulate_step
 
 In addition, the dynamics and observation models can be queried on a single state control input using the `predict` and `measure` methods respectively.
 
-```@docs 
-    predict(::LinearDynamicsModel, ::AbstractVector{<:Number}, ::AbstractVector{<:Number})
-    predict(::NonlinearDynamicsModel, ::AbstractVector{<:Number}, ::AbstractVector{<:Number})
-    measure(::LinearObservationModel, ::AbstractVector{<:Number}, ::AbstractVector{<:Number})
-    measure(::NonlinearObservationModel, ::AbstractVector{<:Number}, ::AbstractVector{<:Number})
+```@docs
+predict(::LinearDynamicsModel, ::AbstractVector{<:Number}, ::AbstractVector{<:Number})
+predict(::NonlinearDynamicsModel, ::AbstractVector{<:Number}, ::AbstractVector{<:Number})
+measure(::LinearObservationModel, ::AbstractVector{<:Number}, ::AbstractVector{<:Number})
+measure(::NonlinearObservationModel, ::AbstractVector{<:Number}, ::AbstractVector{<:Number})
 ```
 
 ## Running a Filter
@@ -61,9 +71,13 @@ GaussianFilters.run_filter
 Alternatively, you can make step-wise belief updates using the `update` function, which consists of a two-step process to a) `predict` the next state given a known action and b) make measurement-based belief updates with `measure`.
 
 ```@docs
-GaussianFilters.update
-GaussianFilters.predict
-GaussianFilters.measure
+update(::AbstractFilter, ::GaussianBelief, ::AbstractVector{<:Number}, ::AbstractVector{<:Number})
+predict(::KalmanFilter, ::GaussianBelief, ::AbstractVector{<:Number})
+predict(::ExtendedKalmanFilter, ::GaussianBelief, ::AbstractVector{<:Number})
+predict(::UnscentedKalmanFilter, ::GaussianBelief, ::AbstractVector{<:Number})
+measure(::KalmanFilter, ::GaussianBelief, ::AbstractVector{<:Number})
+measure(::ExtendedKalmanFilter, ::GaussianBelief, ::AbstractVector{a}) where a<:Number
+measure(::UnscentedKalmanFilter, ::GaussianBelief, ::AbstractVector{<:Number})
 ```
 
 
@@ -83,10 +97,8 @@ GaussianFilters.belief_ellipse
 
 ## Examples
 
-Full implementation examples can be found in the `notebooks` folder of the repo:
+Full implementation examples can be found in the [`examples/`](https://github.com/sisl/GaussianFilters.jl/tree/master/examples) directory of the repo:
 
-[Kalman Filter Example](https://github.com/sisl/GaussianFilters.jl/blob/master/notebooks/KF_2DMotionExample.ipynb)
-
-[Extended Kalman Filter Example](https://github.com/sisl/GaussianFilters.jl/blob/master/notebooks/EKF_SpinningSatelliteExample.ipynb)
-
-[Unscented Kalman Filter Example](https://github.com/sisl/GaussianFilters.jl/blob/master/notebooks/UKF_NonholonomicRobot.ipynb)
+- [`kf_2d_motion.jl`](https://github.com/sisl/GaussianFilters.jl/blob/master/examples/kf_2d_motion.jl) — Kalman Filter
+- [`ekf_spinning_satellite.jl`](https://github.com/sisl/GaussianFilters.jl/blob/master/examples/ekf_spinning_satellite.jl) — Extended Kalman Filter
+- [`ukf_nonholonomic_robot.jl`](https://github.com/sisl/GaussianFilters.jl/blob/master/examples/ukf_nonholonomic_robot.jl) — Unscented Kalman Filter

--- a/docs/src/kalman.md
+++ b/docs/src/kalman.md
@@ -95,20 +95,8 @@ GaussianFilters.unpack
 GaussianFilters.belief_ellipse
 ```
 
-## POMDPs.jl integration
-
-When [POMDPs.jl](https://github.com/JuliaPOMDP/POMDPs.jl) is also
-loaded, a package extension wires GaussianFilters' `AbstractFilter`
-into the POMDPs belief-updater interface. Use `pomdps_updater` to
-obtain a `POMDPs.Updater` wrapper suitable for `POMDPs.simulate` and
-related simulators.
-
-```@docs
-GaussianFilters.pomdps_updater
-```
-
-See `examples/pomdps_integration.jl` and `examples/pendulum_ekf_ilqr.jl`
-for end-to-end usage.
+For interoperability with the POMDPs.jl belief-updater interface, see the
+[POMDPs.jl Integration](pomdps.md) page.
 
 ## Examples
 
@@ -117,5 +105,3 @@ Full implementation examples can be found in the [`examples/`](https://github.co
 - [`kf_2d_motion.jl`](https://github.com/sisl/GaussianFilters.jl/blob/master/examples/kf_2d_motion.jl) — Kalman Filter
 - [`ekf_spinning_satellite.jl`](https://github.com/sisl/GaussianFilters.jl/blob/master/examples/ekf_spinning_satellite.jl) — Extended Kalman Filter
 - [`ukf_nonholonomic_robot.jl`](https://github.com/sisl/GaussianFilters.jl/blob/master/examples/ukf_nonholonomic_robot.jl) — Unscented Kalman Filter
-- [`pomdps_integration.jl`](https://github.com/sisl/GaussianFilters.jl/blob/master/examples/pomdps_integration.jl) — KF used through `POMDPs.update`
-- [`pendulum_ekf_ilqr.jl`](https://github.com/sisl/GaussianFilters.jl/blob/master/examples/pendulum_ekf_ilqr.jl) — EKF + iLQR closed loop driven by `POMDPs.simulate`

--- a/docs/src/pomdps.md
+++ b/docs/src/pomdps.md
@@ -1,0 +1,83 @@
+# POMDPs.jl Integration
+
+```@meta
+CurrentModule = GaussianFilters
+```
+
+GaussianFilters ships with a [POMDPs.jl](https://github.com/JuliaPOMDP/POMDPs.jl)
+package extension that activates automatically when both packages are loaded.
+The extension wires `AbstractFilter` into the POMDPs belief-updater interface
+so that a Kalman, Extended Kalman, or Unscented Kalman filter can be used
+directly as a `POMDPs.Updater` — including with simulators such as
+`HistoryRecorder` and policy/planner code that expects the standard POMDPs
+interface.
+
+## Quick start
+
+```julia
+using GaussianFilters
+using POMDPs
+using POMDPTools
+
+# 1. Build a filter as usual
+dmodel = NonlinearDynamicsModel(f, W)
+omodel = NonlinearObservationModel(h, V)
+ekf    = ExtendedKalmanFilter(dmodel, omodel)
+
+# 2. Wrap it as a POMDPs.Updater
+updater = pomdps_updater(ekf)
+
+# 3. Pass it to any POMDPs.jl simulator
+hist = simulate(HistoryRecorder(max_steps=60), pomdp, policy, updater)
+```
+
+The wrapper is needed because POMDPs.jl simulators dispatch on the abstract
+type `POMDPs.Updater`, and `AbstractFilter` cannot subtype `POMDPs.Updater`
+directly without making POMDPs.jl a hard dependency.
+
+## Direct dispatch (without the wrapper)
+
+For simpler use cases that don't need the full `POMDPs.simulate` machinery,
+the extension also overloads `POMDPs.update` and `POMDPs.initialize_belief`
+directly on `AbstractFilter`:
+
+```julia
+b1 = POMDPs.update(ekf, b0, action, observation)
+```
+
+This is convenient when integrating with code that calls `POMDPs.update`
+generically but does not require the `<:Updater` subtype constraint.
+
+## Initial beliefs from distributions
+
+The extension supports initializing a `GaussianBelief` from any multivariate
+normal distribution. This is useful when the initial state of a `POMDP` is
+given as an `MvNormal`:
+
+```julia
+using Distributions
+prior = MvNormal([0.0, 0.0], [1.0 0.0; 0.0 0.5])
+b0    = POMDPs.initialize_belief(updater, prior)
+```
+
+## API
+
+```@docs
+GaussianFilters.pomdps_updater
+```
+
+## Examples
+
+Two example scripts live in the
+[`examples/`](https://github.com/sisl/GaussianFilters.jl/tree/master/examples)
+directory:
+
+- [`pomdps_integration.jl`](https://github.com/sisl/GaussianFilters.jl/blob/master/examples/pomdps_integration.jl) —
+  a minimal demonstration of using a `KalmanFilter` through `POMDPs.update`.
+
+- [`pendulum_ekf_ilqr.jl`](https://github.com/sisl/GaussianFilters.jl/blob/master/examples/pendulum_ekf_ilqr.jl) —
+  closed-loop stabilization of a noisy inverted pendulum observed only
+  through its angular velocity. Defines a `PendulumPOMDP`, an
+  `ILQRPolicy <: POMDPs.Policy` that runs iterative LQR on the belief
+  mean (certainty equivalent control), wraps the EKF with `pomdps_updater`,
+  and drives the whole closed loop through `POMDPs.simulate`.


### PR DESCRIPTION
Bundle of documentation modernization changes needed for docs to build and deploy again after several years of a broken Travis-based pipeline.

**`build(docs): update Documenter API for 1.x compat`** — replaces `format = :html` (Documenter 0.x) with `format = Documenter.HTML()` (Documenter 1.x). The `:html` form raises `Cannot convert Symbol to Documenter.Writer` under current Documenter.

**`docs: surface missing docstrings, resolve duplicate @docs, fix example links`** — surfaces 6 previously-undocumented public symbols (`AbstractFilter`, `DynamicsModel`, `ObservationModel`, `unscented_transform`, `unscented_transform_inverse`, `MvNormalPDF`) by adding them to the appropriate `@docs` blocks. Disambiguates duplicate `@docs` references (the bare `GaussianFilters.update`/`predict`/`measure` references on both `kalman.md` and `gmphd.md` were pulling in every method and producing duplicate entries — now method-signature-qualified per page). Updates Example links from `notebooks/*.ipynb` to `examples/*.jl`. `docs/Project.toml` gains a `[sources]` path entry so docs build against the in-tree source.

**`docs(kalman): document pomdps_updater and link POMDPs.jl examples`** — initial integration mention in `kalman.md` (later moved out by the next commit).

**`docs: promote POMDPs.jl integration to its own page`** — moves the POMDPs content out of `kalman.md` into a new `docs/src/pomdps.md` under a new `Integrations` section. Adds a quick-start code snippet, documents direct dispatch vs the `pomdps_updater` wrapper, and shows initializing a belief from an `MvNormal`.

**`ci: add Documentation workflow (deploy on master, preview on PRs)`** — new `.github/workflows/documentation.yml` that builds and deploys docs to `gh-pages` on master pushes and generates docs previews on PRs. Uses `julia-actions/setup-julia` + `julia-actions/cache` and runs `docs/make.jl` with GitHub Actions token auth. Wraps `deploydocs()` in an `ENV["CI"]` gate and makes `prettyurls` CI-only so local docs builds don't attempt to deploy. This is the docs-side companion to the CI+Codecov migration in #62.

Verified locally — docs build cleanly with no `missing_docs` or `docs_block` errors.