### PR TITLE
Bump version to v0.2.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GaussianFilters"
 uuid = "08d575fb-911d-541e-8431-6cfa767e7851"
 authors = ["Arec Jamgochian <arec.jamgochian@gmail.com>"]
-version = "0.1.3"
+version = "0.2.0"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"


### PR DESCRIPTION
Prepares a v0.2.0 release. The changes since v0.1.3 are substantial and include breaking-ish adjustments, so a minor bump is warranted.

### Notable changes since v0.1.3

- `julia` compat floor: `1` → `1.9` (POMDPs extension requires `[weakdeps]`, Julia 1.9+)
- `ForwardDiff` compat: `0.9, 0.10` → `0.10, 1`
- `Distributions` compat: long legacy list → `0.25`
- Filter and model struct types (`KalmanFilter`, `ExtendedKalmanFilter`, `UnscentedKalmanFilter`, `Measurement`, `Dynamics`, `Spawn`, `PHDFilter`) are now parametric. Any user code that annotated method arguments with the bare struct name (e.g. `::KalmanFilter`) still works; code that used old `{T,S,...}` internal parameter forms may need updates.
- `rand(rng, ::GaussianBelief)` and `simulation()` now actually thread the RNG through — reproducibility semantics changed. Tests were regenerated in #56.
- New `GaussianBelief(μ, ::UniformScaling)` constructor (#57).
- New POMDPs.jl integration via weak-dep extension (#59): `pomdps_updater`, `GaussianFilterUpdater`, direct `POMDPs.update`/`initialize_belief` dispatch on `AbstractFilter`.
- CI migrated from Travis to GitHub Actions (#62); docs migrated to Documenter 1.x and gained a POMDPs.jl integration page (#60).
- `notebooks/` migrated to `examples/` .jl scripts (#52).